### PR TITLE
Add DeFiat Voting Power strategy

### DIFF
--- a/src/strategies/defiat/README.md
+++ b/src/strategies/defiat/README.md
@@ -1,0 +1,13 @@
+# DeFiat
+
+Snapshot strategy to calculate total DFT exposure at a given block and grant equivalent voting power via Smart Contract call.
+
+DeFiat_VotingPower Contract: https://etherscan.io/address/0x594aca0b33b041b8d66d482daccc7819fee45e0a#code
+
+This contract grants voting power based on the following formula:  
+`Voting_Power = Total_DFT_Balance + Total_DFT_Staked + Total_DFT_Rewards_Pending + (Total_DFT-UNI-V2_Staked * DFT_PER_UNI_V2)`  
+
+Current whitelisted staking pools are the following:  
+- DFT Dungeon: https://etherscan.io/address/0xB508Dd7EeD4517bc66462cd384c0849d99B160fc  
+- Points Palace: https://etherscan.io/address/0x973a2B39F7D59C0E59097f26C0921b60597aFe57  
+- Liquidity Lab: https://etherscan.io/address/0x7BACeF5001203724B1D8b5480dfb7238fcA1375c  

--- a/src/strategies/defiat/index.ts
+++ b/src/strategies/defiat/index.ts
@@ -1,0 +1,58 @@
+import { formatUnits } from '@ethersproject/units';
+import { multicall } from '../../utils';
+
+export const author = 'quantsoldier';
+export const version = '1.0.0';
+
+const DEFIAT_VOTING_POWER = {
+  '1': '0x594AcA0b33B041b8d66D482daCCc7819feE45e0a'
+};
+
+const abi = [
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_address",
+        type: "address"
+      }
+    ],
+    name: "myVotingPower",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256"
+      }
+    ],
+    stateMutability: "view",
+    type: "function"
+  }
+];
+
+export async function strategy(
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const response = await multicall(
+    network,
+    provider,
+    abi,
+    addresses.map((address: any) => [
+      DEFIAT_VOTING_POWER[network],
+      "myVotingPower",
+      [address.toLowerCase()],
+      { blockTag }
+    ])
+  );
+  return Object.fromEntries(
+    response.map((value, i) => [
+      addresses[i],
+      parseFloat(formatUnits(value.toString(), options.decimals))
+    ])
+  );
+}


### PR DESCRIPTION
Adds a voting power strategy specific to DeFiat and its staking system. The goal of this PR is to be able to fairly allocate votes among all participants of the network, regardless of token holding status. This proved to be too gas-intensive to manage ourselves, so to Snapshot we go!

Changes proposed in this pull request:
- Add DeFiat Voting Power Strategy & README 
- Smart Contract code is published on Etherscan

https://etherscan.io/address/0x594aca0b33b041b8d66d482daccc7819fee45e0a#code
