### PR TITLE
Add Jurors Registry ANJ strategy

### DIFF
--- a/src/strategies/anj-staked/index.ts
+++ b/src/strategies/anj-staked/index.ts
@@ -1,0 +1,45 @@
+import { formatUnits } from '@ethersproject/units';
+import { multicall } from '../../utils';
+
+export const author = 'Evalir';
+export const version = '0.1.0';
+
+const abi = [
+  {
+    constant: true,
+    inputs: [{ name: '_juror', type: 'address' }],
+    name: 'totalStakedFor',
+    outputs: [{ name: '', type: 'uint256' }],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function'
+  }
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const response = await multicall(
+    network,
+    provider,
+    abi,
+    addresses.map((address: any) => [
+      options.jurorsRegistry,
+      'totalStakedFor',
+      [address]
+    ]),
+    { blockTag }
+  );
+  return Object.fromEntries(
+    response.map((value, i) => [
+      addresses[i],
+      parseFloat(formatUnits(value.toString(), options.decimals))
+    ])
+  );
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -1,3 +1,4 @@
+import { strategy as anjStaked } from './anj-staked';
 import { strategy as balancer } from './balancer';
 import { strategy as contractCall } from './contract-call';
 import { strategy as erc20BalanceOf } from './erc20-balance-of';
@@ -18,6 +19,7 @@ import { strategy as ctoken } from './ctoken';
 import { strategy as cream } from './cream';
 
 export default {
+  'anj-staked': anjStaked,
   balancer,
   'contract-call': contractCall,
   'erc20-balance-of': erc20BalanceOf,


### PR DESCRIPTION
Changes proposed in this pull request:
- Add a strategy for fetching the balance of an Aragon Network Juror in the [Jurors Registry](0x0F7471C1df2021fF45f112878F755aAbe7AA16bF), so that they can vote even if they have their ANJ staked.
