### PR TITLE
Please add Meter.io mainet information

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -82,6 +82,16 @@
     ],
     "explorer": "https://blockscout.com/etc/mainnet"
   },
+  "82": {
+    "key": "82",
+    "name": "Meter.io Mainnet",
+    "chainId": 82,
+    "network": "mainnet",
+    "rpc": [
+      "https://rpc.meter.io"
+    ],
+    "explorer": "https://scan.meter.io"
+  },
   "97": {
     "key": "97",
     "name": "Binance Smart Chain Testnet",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,6 +20,7 @@ export const MULTICALL = {
   '6': '0x53c43764255c17bd724f74c4ef150724ac50a3ed',
   '42': '0x2cc8688c5f75e365aaeeb4ea8d6a480405a48d2a',
   '56': '0x1ee38d535d541c55c9dae27b12edf090c608e6fb',
+  '82': '0x579De77CAEd0614e3b158cb738fcD5131B9719Ae',
   '97': '0x8b54247c6BAe96A6ccAFa468ebae96c4D7445e46',
   '100': '0xb5b692a88bdfc81ca69dcb1d924f59f0413a602a',
   wanchain: '0xba5934ab3056fca1fa458d30fbb3810c3eb5145f'


### PR DESCRIPTION
Need to add the following in web3 to interact with Meter mainnet
const meterify = require(“meterify”).meterify;
const Web3 = require(“web3");
const web3 = meterify(new Web3(), “https://rpc.meter.io”);

Fixes # .

Changes proposed in this pull request:
adding meter main net network information and multicall contract address
The meterify library can be found in https://github.com/meterio/meterify
- 
- 
