### PR TITLE
Add mithcash strategy

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -28,6 +28,7 @@ import { strategy as ethPhilanthropy } from './eth-philanthropy';
 import { strategy as xDaiStake } from './xdai-stake';
 import { strategy as defidollar } from './defidollar';
 import { strategy as aavegotchi } from './aavegotchi';
+import { strategy as mithcash } from './mithcash';
 
 export default {
   balancer,
@@ -59,5 +60,6 @@ export default {
   piedao,
   'xdai-stake': xDaiStake,
   defidollar,
-  aavegotchi
+  aavegotchi,
+  mithcash
 };

--- a/src/strategies/mithcash/examples.json
+++ b/src/strategies/mithcash/examples.json
@@ -1,0 +1,22 @@
+[
+    {
+        "name": "MITH Cash",
+        "strategy": {
+            "name": "mithcash",
+            "params": {
+                "sushiswap": "0x066F3A3B7C8Fa077c71B9184d862ed0A4D5cF3e0",
+                "boardroom": "0xb35f89160d1Dc47B6EAC1986D7821505c327AE09",
+                "sharePool": "0x14E33e1D6Cc4D83D7476492C0A52b3d4F869d892",
+                "token": "0x4b4D2e899658FB59b1D518b68fe836B100ee8958",
+                "decimals": 18
+            }
+        },
+        "network": "1",
+        "addresses": [
+            "0x0c11d0bde11fc110caf84d9361a1466adedf59b6",
+            "0xbEA07b01E8Fe3936A3D206158521A87addB65cfE",
+            "0xF5ecA360c5dE26A46D54b72E49800c87801c719b"
+        ],
+        "snapshot": 11605878
+    }
+]

--- a/src/strategies/mithcash/index.ts
+++ b/src/strategies/mithcash/index.ts
@@ -1,0 +1,133 @@
+import { formatUnits, parseUnits } from '@ethersproject/units';
+import { multicall } from '../../utils';
+
+export const author = 'jeremyHD';
+export const version = '0.1.0';
+
+const abi = [
+  {
+    constant: true,
+    inputs: [{ internalType: 'address', name: '', type: 'address' }],
+    name: 'balanceOf',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'getReserves',
+    outputs: [
+      {
+        internalType: 'uint112',
+        name: '_reserve0',
+        type: 'uint112'
+      },
+      {
+        internalType: 'uint112',
+        name: '_reserve1',
+        type: 'uint112'
+      },
+      {
+        internalType: 'uint32',
+        name: '_blockTimestampLast',
+        type: 'uint32'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'totalSupply',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  }
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const response = await multicall(
+    network,
+    provider,
+    abi,
+    [
+      [options.token, 'balanceOf', [options.sushiswap]],
+      [options.sushiswap, 'totalSupply'],
+      ...addresses.map((address: any) => [
+        options.sushiswap,
+        'balanceOf',
+        [address]
+      ]),
+      ...addresses.map((address: any) => [
+        options.sharePool,
+        'balanceOf',
+        [address]
+      ]),
+      ...addresses.map((address: any) => [
+        options.token,
+        'balanceOf',
+        [address]
+      ]),
+      ...addresses.map((address: any) => [
+        options.boardroom,
+        'balanceOf',
+        [address]
+      ])
+    ],
+    { blockTag }
+  );
+
+  const misPerLP = parseUnits(response[0][0].toString(), 18).div(
+    response[1][0]
+  );
+  const lpBalances = response.slice(2, addresses.length + 2);
+  const stakedLpBalances = response.slice(
+    addresses.length + 2,
+    addresses.length * 2 + 2
+  );
+  const tokenBalances = response.slice(
+    addresses.length * 2 + 2,
+    addresses.length * 3 + 2
+  );
+  const boardroomBalances = response.slice(
+    addresses.length * 3 + 2,
+    addresses.length * 4 + 2
+  );
+
+  return Object.fromEntries(
+    Array(addresses.length)
+      .fill('')
+      .map((_, i) => {
+        const lpBalance = lpBalances[i][0].add(stakedLpBalances[i][0]);
+        const misLpBalance = lpBalance.mul(misPerLP).div(parseUnits('1', 18));
+
+        return [
+          addresses[i],
+          parseFloat(
+            formatUnits(
+              misLpBalance
+                .add(tokenBalances[i][0])
+                .add(boardroomBalances[i][0]),
+              options.decimals
+            )
+          )
+        ];
+      })
+  );
+}

--- a/src/strategies/mithcash/index.ts
+++ b/src/strategies/mithcash/index.ts
@@ -7,33 +7,16 @@ export const version = '0.1.0';
 const abi = [
   {
     constant: true,
-    inputs: [{ internalType: 'address', name: '', type: 'address' }],
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address'
+      }
+    ],
     name: 'balanceOf',
     outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
     payable: false,
-    stateMutability: 'view',
-    type: 'function'
-  },
-  {
-    inputs: [],
-    name: 'getReserves',
-    outputs: [
-      {
-        internalType: 'uint112',
-        name: '_reserve0',
-        type: 'uint112'
-      },
-      {
-        internalType: 'uint112',
-        name: '_reserve1',
-        type: 'uint112'
-      },
-      {
-        internalType: 'uint32',
-        name: '_blockTimestampLast',
-        type: 'uint32'
-      }
-    ],
     stateMutability: 'view',
     type: 'function'
   },


### PR DESCRIPTION
Changes proposed in this pull request:
- Added a strategy that calculates the user's voting power based on the balance of MIS tokens and the amount of tokens staked in boardroom and provided liquidity in Sushiswap.