### PR TITLE
Add Staked KEEP

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -31,6 +31,7 @@ import { strategy as aavegotchi } from './aavegotchi';
 import { strategy as mithcash } from './mithcash';
 import { strategy as dittomoney } from './dittomoney';
 import { strategy as balancerUnipool } from './balancer-unipool';
+import { strategy as stakedKeep } from './staked-keep';
 
 export default {
   balancer,
@@ -65,5 +66,6 @@ export default {
   aavegotchi,
   mithcash,
   dittomoney,
+  'staked-keep': stakedKeep,
   'balancer-unipool': balancerUnipool
 };

--- a/src/strategies/staked-keep/README.md
+++ b/src/strategies/staked-keep/README.md
@@ -1,0 +1,11 @@
+## Explanation
+This strategy just gets the amount of KEEP that an address has staked in the operators that it owns.
+
+## Parameters
+This strategy doesn't take any parameters.
+
+## Testing
+The numbers can be cross-checked against [All The Keeps](https://allthekeeps.com/operators).
+
+## Notes
+Some of the addresses provided in `examples.json` don't have any operators associated with them and thus don't have any staked KEEP.

--- a/src/strategies/staked-keep/examples.json
+++ b/src/strategies/staked-keep/examples.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "Staked Keep Example Query",
+    "strategy": {
+      "name": "staked-keep"
+    },
+    "network": "1",
+    "addresses": [
+      "0x61912E0A8CB64061B9034B324E5ADbEB8dDDc673",
+      "0x8540F80Fab2AFCAe8d8FD6b1557B1Cf943A0999b",
+      "0xad32A8e6220741182940c5aBF610bDE99E737b2D",
+      "0xB8A3AE209d153560993BFd8178E60F09B1c682E8",
+      "0x3d24D77bEC08549D7Ea86c4e9937204C11E153f1"
+    ],
+    "snapshot": 11668787
+  }
+]

--- a/src/strategies/staked-keep/index.ts
+++ b/src/strategies/staked-keep/index.ts
@@ -1,0 +1,45 @@
+import { getAddress } from '@ethersproject/address';
+import { subgraphRequest } from '../../utils';
+
+const UNISWAP_SUBGRAPH_URL = {
+  '1': 'https://api.thegraph.com/subgraphs/name/miracle2k/all-the-keeps'
+};
+
+export const author = 'corollari';
+export const version = '0.1.0';
+
+export async function strategy(
+  _space,
+  network,
+  _provider,
+  addresses,
+  _options,
+  snapshot
+) {
+  const params = {
+    operators: {
+      __args: {
+        where: {
+          owner_in: addresses.map((address) => address.toLowerCase())
+        },
+        first: 1000
+      },
+      owner: true,
+      stakedAmount: true,
+    }
+  };
+  if (snapshot !== 'latest') {
+    // @ts-ignore
+    params.operators.__args.block = { number: snapshot };
+  }
+  const result = await subgraphRequest(UNISWAP_SUBGRAPH_URL[network], params);
+  const score = {};
+  if (result && result.operators) {
+    result.operators.forEach((op) => {
+        const userAddress = getAddress(op.owner);
+        if (!score[userAddress]) score[userAddress] = 0;
+        score[userAddress] = score[userAddress] + Number(op.stakedAmount);
+    });
+  }
+  return score;
+}

--- a/src/strategies/staked-keep/index.ts
+++ b/src/strategies/staked-keep/index.ts
@@ -1,7 +1,7 @@
 import { getAddress } from '@ethersproject/address';
 import { subgraphRequest } from '../../utils';
 
-const UNISWAP_SUBGRAPH_URL = {
+const KEEP_SUBGRAPH_URL = {
   '1': 'https://api.thegraph.com/subgraphs/name/miracle2k/all-the-keeps'
 };
 
@@ -32,7 +32,7 @@ export async function strategy(
     // @ts-ignore
     params.operators.__args.block = { number: snapshot };
   }
-  const result = await subgraphRequest(UNISWAP_SUBGRAPH_URL[network], params);
+  const result = await subgraphRequest(KEEP_SUBGRAPH_URL[network], params);
   const score = {};
   if (result && result.operators) {
     result.operators.forEach((op) => {


### PR DESCRIPTION
As the title says, this PR just adds a strategy that counts the number of KEEP tokens staked by an address.

I forked it from the `uniswap` strategy and tested it with `npm run test --strategy=staked-keep`.