### PR TITLE
Add Sushiswap LP token strategy

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -34,6 +34,7 @@ import { strategy as aavegotchi } from './aavegotchi';
 import { strategy as mithcash } from './mithcash';
 import { strategy as dittomoney } from './dittomoney';
 import { strategy as balancerUnipool } from './balancer-unipool';
+import { strategy as sushiswap } from './sushiswap';
 import { strategy as stablexswap } from './stablexswap';
 import { strategy as stakedKeep } from './staked-keep';
 import { strategy as typhoon } from './typhoon';
@@ -64,6 +65,7 @@ export default {
   uni,
   'yearn-vault': yearnVault,
   moloch,
+  sushiswap,
   uniswap,
   pancake,
   synthetix,

--- a/src/strategies/sushiswap/examples.json
+++ b/src/strategies/sushiswap/examples.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "sushiswap",
+      "params": {
+        "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "symbol": "DAI"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x79317fc0fb17bc0ce213a2b50f343e4d4c277704"
+    ],
+    "snapshot": 1111000
+  }
+]

--- a/src/strategies/sushiswap/index.ts
+++ b/src/strategies/sushiswap/index.ts
@@ -1,0 +1,80 @@
+import { getAddress } from '@ethersproject/address';
+import { subgraphRequest } from '../../utils';
+
+const SUSHISWAP_SUBGRAPH_URL = {
+  '1': 'https://api.thegraph.com/subgraphs/name/sushiswap/exchange'
+};
+
+export const author = 'vfatouros';
+export const version = '0.1.0';
+
+export async function strategy(
+  _space,
+  network,
+  _provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const params = {
+    users: {
+      __args: {
+        where: {
+          id_in: addresses.map((address) => address.toLowerCase())
+        },
+        first: 1000
+      },
+      id: true,
+      liquidityPositions: {
+        __args: {
+          where: {
+            liquidityTokenBalance_gt: 0
+          }
+        },
+        liquidityTokenBalance: true,
+        pair: {
+          id: true,
+          token0: {
+            id: true
+          },
+          reserve0: true,
+          token1: {
+            id: true
+          },
+          reserve1: true,
+          totalSupply: true
+        }
+      }
+    }
+  };
+  if (snapshot !== 'latest') {
+    // @ts-ignore
+    params.users.liquidityPositions.__args.block = { number: snapshot };
+  }
+  const tokenAddress = options.address.toLowerCase();
+  const result = await subgraphRequest(SUSHISWAP_SUBGRAPH_URL[network], params);
+  const score = {};
+  if (result && result.users) {
+    result.users.forEach((u) => {
+      u.liquidityPositions
+        .filter(
+          (lp) =>
+            lp.pair.token0.id == tokenAddress ||
+            lp.pair.token1.id == tokenAddress
+        )
+        .forEach((lp) => {
+          const token0perUni = lp.pair.reserve0 / lp.pair.totalSupply;
+          const token1perUni = lp.pair.reserve1 / lp.pair.totalSupply;
+          const userScore =
+            lp.pair.token0.id == tokenAddress
+              ? token0perUni * lp.liquidityTokenBalance
+              : token1perUni * lp.liquidityTokenBalance;
+
+          const userAddress = getAddress(u.id);
+          if (!score[userAddress]) score[userAddress] = 0;
+          score[userAddress] = score[userAddress] + userScore;
+        });
+    });
+  }
+  return score || {};
+}


### PR DESCRIPTION
Hello! 

This is a PR to add a sushiswap LP token strategy to enable sushi liquidity providers to accurately participate in snapshot voting. 

It has not been confirmed to work, please review.