### PR TITLE
Add Sushi Masterchef LP token strategy

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -35,6 +35,7 @@ import { strategy as mithcash } from './mithcash';
 import { strategy as dittomoney } from './dittomoney';
 import { strategy as balancerUnipool } from './balancer-unipool';
 import { strategy as sushiswap } from './sushiswap';
+import { strategy as masterchef } from './masterchef';
 import { strategy as stablexswap } from './stablexswap';
 import { strategy as stakedKeep } from './staked-keep';
 import { strategy as typhoon } from './typhoon';
@@ -65,6 +66,7 @@ export default {
   uni,
   'yearn-vault': yearnVault,
   moloch,
+  masterchef,
   sushiswap,
   uniswap,
   pancake,

--- a/src/strategies/masterchef/examples.json
+++ b/src/strategies/masterchef/examples.json
@@ -4,14 +4,15 @@
     "strategy": {
       "name": "masterchef",
       "params": {
-        "address": "0x66ae32178640813f3c32a9929520bfe4fef5d167",
-        "symbol": "COVER/ETH"
+        "_comment_": "NOTE: this strategy only supports 1 pool in masterchef. If you need better support, contact @0xKiwi",
+        "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
+        "symbol": "COVER (Masterchef)"
       }
     },
     "network": "1",
     "addresses": [
-      "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713"
+      "0x2073513fdd01a70d4a1eb8b0361b992eb6f1c13b"
     ],
-    "snapshot": 1111000
+    "snapshot": 11838909
   }
 ]

--- a/src/strategies/masterchef/examples.json
+++ b/src/strategies/masterchef/examples.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "masterchef",
+      "params": {
+        "address": "0x66ae32178640813f3c32a9929520bfe4fef5d167",
+        "symbol": "COVER/ETH"
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713"
+    ],
+    "snapshot": 1111000
+  }
+]

--- a/src/strategies/masterchef/index.ts
+++ b/src/strategies/masterchef/index.ts
@@ -1,0 +1,102 @@
+import { getAddress } from '@ethersproject/address';
+import { subgraphRequest } from '../../utils';
+
+const MASTERCHEF_SUBGRAPH_URL = {
+  '1': 'https://api.thegraph.com/subgraphs/name/sushiswap/master-chef'
+};
+
+const SUSHISWAP_SUBGRAPH_URL = {
+  '1': 'https://api.thegraph.com/subgraphs/name/sushiswap/exchange'
+};
+
+export const author = '0xKiwi';
+export const version = '0.1.0';
+
+export async function strategy(
+  _space,
+  network,
+  _provider,
+  address,
+  options,
+  snapshot
+) {
+
+  const masterchefParams = {
+    pool: {
+      __args: {
+        where: {
+          id_in: address.toLowerCase()
+        },
+        first: 1000
+      },
+      id: true,
+      users: {
+        __args: {
+          where: {
+            amount_gt: 0,
+          },
+        },
+        id: true,
+        amount: true,
+      },
+    }
+  };
+  if (snapshot !== 'latest') {
+    // @ts-ignore
+    params.pool.__args.block = { number: snapshot };
+  }
+  const masterchefResult = await subgraphRequest(MASTERCHEF_SUBGRAPH_URL[network], masterchefParams);
+
+  let stakedBalances = []
+  if (masterchefResult && masterchefResult.pool) {
+    stakedBalances = masterchefResult.pool.users.map((u) => {
+      return {
+        id: u.id,
+        amount: u.amount,
+      }
+    })
+  }
+
+  const sushiParams = {
+    pair: {
+      __args: {
+        where: {
+          id_in: address.toLowerCase()
+        },
+        first: 1000
+      },
+      id: true,
+      token0: {
+        id: true
+      },
+      reserve0: true,
+      token1: {
+        id: true
+      },
+      reserve1: true,
+      totalSupply: true
+    }
+  };
+  if (snapshot !== 'latest') {
+    // @ts-ignore
+    params.pair.__args.block = { number: snapshot };
+  }
+  const tokenAddress = options.address.toLowerCase();
+  const sushiResult = await subgraphRequest(SUSHISWAP_SUBGRAPH_URL[network], sushiParams);
+  const score = {};
+  if (sushiResult && sushiResult.pair) {
+    const token0perUni = sushiResult.pair.reserve0 / sushiResult.pair.totalSupply;
+    const token1perUni = sushiResult.pair.reserve1 / sushiResult.pair.totalSupply;
+    stakedBalances.forEach((u) => {
+      const userScore =
+        sushiResult.pair.token0.id == tokenAddress
+          ? token0perUni * u.amount
+          : token1perUni * u.amount;
+
+      const userAddress = getAddress(u.id);
+      if (!score[userAddress]) score[userAddress] = 0;
+      score[userAddress] = score[userAddress] + userScore;
+    });
+  }
+  return score || {};
+}

--- a/src/strategies/masterchef/index.ts
+++ b/src/strategies/masterchef/index.ts
@@ -1,4 +1,5 @@
 import { getAddress } from '@ethersproject/address';
+import { concat } from '@ethersproject/bytes';
 import { subgraphRequest } from '../../utils';
 
 const MASTERCHEF_SUBGRAPH_URL = {
@@ -16,84 +17,119 @@ export async function strategy(
   _space,
   network,
   _provider,
-  address,
+  addresses,
   options,
   snapshot
 ) {
-
-  const masterchefParams = {
-    pool: {
+  const tokenAddress = options.address.toLowerCase();
+  console.log(tokenAddress)
+  const sushiPools0Params = {
+    pairs: {
       __args: {
         where: {
-          id_in: address.toLowerCase()
+          token0: tokenAddress,
         },
-        first: 1000
+        first: 100,
       },
       id: true,
+      token0: {
+        id: true,
+      },
+      reserve0: true,
+      token1: {
+        id: true,
+      },
+      reserve1: true,
+      totalSupply: true,
+    }
+  };
+  const sushiPools1Params = {
+    pairs: {
+      __args: {
+        where: {
+          token1: tokenAddress,
+        },
+        first: 100,
+      },
+      id: true,
+      token0: {
+        id: true,
+      },
+      reserve0: true,
+      token1: {
+        id: true,
+      },
+      reserve1: true,
+      totalSupply: true,
+    }
+  };
+  if (snapshot !== 'latest') {
+    // @ts-ignore
+    sushiPools0Params.pairs.__args.block = { number: snapshot };
+    // @ts-ignore
+    sushiPools1Params.pairs.__args.block = { number: snapshot };
+  }
+  const sushiPools0Result = await subgraphRequest(SUSHISWAP_SUBGRAPH_URL[network], sushiPools0Params);
+  const sushiPools1Result = await subgraphRequest(SUSHISWAP_SUBGRAPH_URL[network], sushiPools1Params);
+  if (!sushiPools0Result || !sushiPools1Result) {
+    return
+  }
+  const allSushiPools = sushiPools0Result.pairs.concat(sushiPools1Result.pairs)
+
+  const pools = allSushiPools.map(({ id }) => id.toLowerCase());
+
+  const masterchefParams = {
+    pools: {
+      __args: {
+        where: {
+          pair_in: pools,
+        },
+        first: 100
+      },
+      id: true,
+      pair: true,
       users: {
         __args: {
           where: {
             amount_gt: 0,
+            address_in: addresses.map((address) => address.toLowerCase())
           },
         },
-        id: true,
+        address: true,
         amount: true,
       },
     }
   };
   if (snapshot !== 'latest') {
     // @ts-ignore
-    params.pool.__args.block = { number: snapshot };
+    masterchefParams.pools.__args.block = { number: snapshot };
   }
   const masterchefResult = await subgraphRequest(MASTERCHEF_SUBGRAPH_URL[network], masterchefParams);
 
   let stakedBalances = []
-  if (masterchefResult && masterchefResult.pool) {
-    stakedBalances = masterchefResult.pool.users.map((u) => {
+  if (masterchefResult && masterchefResult.pools.length == 1) {
+    stakedBalances = masterchefResult.pools[0].users.map((u) => {
       return {
-        id: u.id,
+        address: u.address,
         amount: u.amount,
       }
     })
   }
 
-  const sushiParams = {
-    pair: {
-      __args: {
-        where: {
-          id_in: address.toLowerCase()
-        },
-        first: 1000
-      },
-      id: true,
-      token0: {
-        id: true
-      },
-      reserve0: true,
-      token1: {
-        id: true
-      },
-      reserve1: true,
-      totalSupply: true
-    }
-  };
-  if (snapshot !== 'latest') {
-    // @ts-ignore
-    params.pair.__args.block = { number: snapshot };
-  }
-  const tokenAddress = options.address.toLowerCase();
-  const sushiResult = await subgraphRequest(SUSHISWAP_SUBGRAPH_URL[network], sushiParams);
   const score = {};
-  if (sushiResult && sushiResult.pair) {
-    const token0perUni = sushiResult.pair.reserve0 / sushiResult.pair.totalSupply;
-    const token1perUni = sushiResult.pair.reserve1 / sushiResult.pair.totalSupply;
+  if (allSushiPools && allSushiPools.length > 0) {
+    // We assume there is only one pool in masterchef here, for simplicity.
+    const pair = allSushiPools.filter(({ id }) => id == masterchefResult.pools[0].pair)[0]
+    console.log(pair)
+    const token0perUni = pair.reserve0 / pair.totalSupply;
+    const token1perUni = pair.reserve1 / pair.totalSupply;
     stakedBalances.forEach((u) => {
       const userScore =
-        sushiResult.pair.token0.id == tokenAddress
+        pair.token0.id == tokenAddress
           ? token0perUni * u.amount
           : token1perUni * u.amount;
 
-      const userAddress = getAddress(u.id);
+      const userAddress = getAddress(u.address);
       if (!score[userAddress]) score[userAddress] = 0;
       score[userAddress] = score[userAddress] + userScore;
     });

--- a/src/strategies/sushiswap/examples.json
+++ b/src/strategies/sushiswap/examples.json
@@ -4,14 +4,14 @@
     "strategy": {
       "name": "sushiswap",
       "params": {
-        "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
-        "symbol": "DAI"
+        "address": "0x4688a8b1f292fdab17e9a90c8bc379dc1dbd8713",
+        "symbol": "Cover (sushiswap)"
       }
     },
     "network": "1",
     "addresses": [
-      "0x79317fc0fb17bc0ce213a2b50f343e4d4c277704"
+      "0x3d8d742ee7fbc497ae671528a19a1489ba204482"
     ],
-    "snapshot": 1111000
+    "snapshot": 11618834
   }
 ]


### PR DESCRIPTION
This PR adds a strategy that allows users with their LP tokens staked in Sushi's masterchef to vote in snapshot proposals.

Note: this has not been tested and I'm not entirely familiar with The Graph and its inner workings. Please review and confirm it works however possible.

If there are any changes that need to be made, let me know! Thank you!
