### PR TITLE
feat(ditto-money): add power vote for cafeswap, jetFuel vault and autofarm

### DIFF
--- a/src/strategies/dittomoney/examples.json
+++ b/src/strategies/dittomoney/examples.json
@@ -4,6 +4,9 @@
     "strategy": {
       "name": "dittomoney",
       "params": {
+        "autofarm": "0x0895196562C7868C5Be92459FaE7f877ED450452",
+        "jetfuel": "0x3d6D415be40159f207540f95E398F29a7173dC20",
+        "cafeswap":"0xc772955c33088a97D56d0BBf473d05267bC4feBB",
         "pancake": "0x470BC451810B312BBb1256f96B0895D95eA659B1",
         "sharePool": "0x27Da7Bc5CcB7c31baaeEA8a04CC8Bf0085017208",
         "token": "0x233d91a0713155003fc4dce0afa871b508b3b715",
@@ -12,12 +15,13 @@
     },
     "network": "56",
     "addresses": [
+      "0xff91AcCd5277cc3de3E73DD77e3102b1980e439e",
       "0x05ff2b0db69458a0750badebc4f9e13add608c7f",
       "0xd1a8Dd23e356B9fAE27dF5DeF9ea025A602EC81e",
       "0x48f7cb174a2333de834452ad240ce8d3d827dc55",
       "0x0d3cae1ff719d6a2ac0fcd7cd22f599cac64b6ec",
       "0xE0e710A907a8E44c078e6212Efa336C1191F4CD1"
     ],
-    "snapshot": 4018707
+    "snapshot": 5248103
   }
 ]

--- a/src/strategies/dittomoney/index.ts
+++ b/src/strategies/dittomoney/index.ts
@@ -1,8 +1,9 @@
 import { formatUnits, parseUnits } from '@ethersproject/units';
 import Multicaller from '../../utils/multicaller';
+import { multicall } from '../../utils';
 
 export const author = 'codingsh';
-export const version = '0.1.0';
+export const version = '0.1.1';
 
 const abi = [
   {
@@ -47,6 +48,21 @@ const abi = [
     payable: false,
     stateMutability: 'view',
     type: 'function'
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'getPricePerFullShare',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      }
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function'
   }
 ];
 
@@ -62,8 +78,13 @@ export async function strategy(
 
   const multi = new Multicaller(network, provider, abi, { blockTag });
 
+  multi.call('cafeswapBalance', options.token, 'balanceOf', [options.cafeswap]);
+  multi.call('jetfuelBalance', options.token, 'balanceOf', [options.jetfuel]);
+  multi.call('jetfuelTotalSupply', options.jetfuel, 'totalSupply');
+  multi.call('autofarmBalance', options.token, 'balanceOf', [options.autofarm]);
   multi.call('pancakeBalance', options.token, 'balanceOf', [options.pancake]);
   multi.call('pancakeTotalSupply', options.pancake, 'totalSupply');
+  multi.call('pricePerFullShare', options.jetfuel, 'getPricePerFullShare');
   addresses.forEach((address) => {
     multi.call(
       `scores.${address}.totalStaked`,
@@ -74,6 +95,9 @@ export async function strategy(
     multi.call(`scores.${address}.pancake`, options.pancake, 'balanceOf', [
       address
     ]);
+    multi.call(`scores.${address}.jetfuel`, options.jetfuel, 'balanceOf', [
+      address
+    ]);
     multi.call(`scores.${address}.balance`, options.token, 'balanceOf', [
       address
     ]);
@@ -81,22 +105,34 @@ export async function strategy(
 
   const result = await multi.execute();
   const dittoPerLP = result.pancakeBalance;
+  const autofarmBalance = result.autofarmBalance;
+  const cafeswapBalance = result.cafeswapBalance;
+  const pricePerFullShare = result.pricePerFullShare;
 
   return Object.fromEntries(
     Array(addresses.length)
       .fill('')
       .map((_, i) => {
         const lpBalances = result.scores[addresses[i]].pancake;
+        const lpBalancesJetFuel = result.scores[addresses[i]].jetfuel;
         const stakedLpBalances = result.scores[addresses[i]].totalStaked;
         const tokenBalances = result.scores[addresses[i]].balance;
         const lpBalance = lpBalances.add(stakedLpBalances);
         const dittoLpBalance = lpBalance
           .mul(dittoPerLP)
           .div(parseUnits('1', 18));
+        const dittoFuelBalance = lpBalancesJetFuel
+          .mul(pricePerFullShare)
         return [
           addresses[i],
           parseFloat(
-            formatUnits(dittoLpBalance.add(tokenBalances), options.decimals)
+            formatUnits(
+              dittoLpBalance
+                .add(tokenBalances)
+                .add(dittoFuelBalance)
+                .add(autofarmBalance)
+                .add(cafeswapBalance),
+              options.decimals)
           )
         ];
       })


### PR DESCRIPTION
Upgrade Ditto Strategy 

Changes proposed in this pull request:
-  add CafeSwap Balance
-  add JetFuel Vaults
-  add Autorfarm Balance

**npm run test --strategy=dittomoney**
```console
> @snapshot-labs/snapshot.js@0.1.6 test
> node test/index.ts

Strategy: "dittomoney"
Ditto.money
[
  {
    '0x614812d04526C0C882A6cB993a135fcD559F33F9': 3423.997380018601,
    '0xff91AcCd5277cc3de3E73DD77e3102b1980e439e': 1031512744857019.1,
    '0x05ff2b0db69458a0750badebc4f9e13add608c7f': 0,
    '0xd1a8Dd23e356B9fAE27dF5DeF9ea025A602EC81e': 0.000104180662529254,
    '0x48f7cb174a2333de834452ad240ce8d3d827dc55': 1.130252e-11,
    '0x0d3cae1ff719d6a2ac0fcd7cd22f599cac64b6ec': 59.320683326386295,
    '0xE0e710A907a8E44c078e6212Efa336C1191F4CD1': 1.130252e-11
  }
]
getScores: 3.504s