### PR TITLE
feat(strategies): add Rebased strategy

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -50,6 +50,7 @@ import { strategy as theGraphDelegation } from './the-graph-delegation';
 import { strategy as theGraphIndexing } from './the-graph-indexing';
 import { strategy as whitelist } from './whitelist';
 import { strategy as tokenlon } from './tokenlon';
+import { strategy as rebased } from './rebased';
 
 export default {
   balancer,
@@ -103,5 +104,6 @@ export default {
   'the-graph-delegation': theGraphDelegation,
   'the-graph-indexing': theGraphIndexing,
   whitelist,
-  tokenlon
+  tokenlon,
+  rebased
 };

--- a/src/strategies/rebased/examples.json
+++ b/src/strategies/rebased/examples.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "Rebased",
+    "strategy": {
+      "name": "rebased",
+      "params": {
+        "uniswap": "0x54f5f952cca8888227276581F26978F99FDBa64E",
+        "sharePool": "0x574D80f005B9f5a26e6D4E0bcbD379EABD7edEb0",
+        "token": "0x87f5f9ebe40786d49d35e1b5997b07ccaa8adbff",
+        "decimals": 18
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xde389fb34f54bec6d09bd98152a69be15c43163f",
+      "0xbe80fd79e26ce0a605e5d2803e876f1b009d70cc",
+      "0x55c307cbe54a1c1c105838a9d0fd60b75d7ff951",
+      "0x01BaD7E976d59CE92295Dbacd5da7fc06FE05412",
+      "0x64be824f732312490224a67537d49b8580068abf"
+    ],
+    "snapshot": 11941425
+  }
+]

--- a/src/strategies/rebased/index.ts
+++ b/src/strategies/rebased/index.ts
@@ -1,0 +1,108 @@
+import { formatUnits, parseUnits } from '@ethersproject/units';
+import Multicaller from '../../utils/multicaller';
+import { multicall } from '../../utils';
+
+export const author = 'codingsh';
+export const version = '0.1.0';
+
+const abi = [
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address'
+      }
+    ],
+    name: 'balanceOf',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'totalSupply',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'addr',
+        type: 'address'
+      }
+    ],
+    name: 'totalStakedFor',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function'
+  }
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const multi = new Multicaller(network, provider, abi, { blockTag });
+
+  multi.call('uniswapBalance', options.token, 'balanceOf', [options.uniswap]);
+  multi.call('uniswapTotalSupply', options.uniswap, 'totalSupply');
+  addresses.forEach((address) => {
+    multi.call(
+      `scores.${address}.totalStaked`,
+      options.sharePool,
+      'totalStakedFor',
+      [address]
+    );
+    multi.call(`scores.${address}.uniswap`, options.uniswap, 'balanceOf', [
+      address
+    ]);
+    multi.call(`scores.${address}.balance`, options.token, 'balanceOf', [
+      address
+    ]);
+  });
+
+  const result = await multi.execute();
+  const rebasedPerLP = result.uniswapBalance;
+
+  return Object.fromEntries(
+    Array(addresses.length)
+      .fill('')
+      .map((_, i) => {
+        const lpBalances = result.scores[addresses[i]].uniswap;
+        const stakedLpBalances = result.scores[addresses[i]].totalStaked;
+        const tokenBalances = result.scores[addresses[i]].balance;
+        const lpBalance = lpBalances.add(stakedLpBalances);
+        const rebasedLpBalance = lpBalance
+          .add(tokenBalances)
+          .mul(rebasedPerLP)
+          .div(parseUnits('1', 18));
+        return [
+          addresses[i],
+          parseFloat(
+            formatUnits(
+              rebasedLpBalance,
+              options.decimals)
+          )
+        ];
+      })
+  );
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- voting power for staking users
- voting power for users who hold the RebasedV2 token

**npm run test --strategy=rebased**

```console
Strategy: "rebased"
Rebased
[
  {
    '0xde389fb34f54bec6d09bd98152a69be15c43163f': 4.326101359e-9,
    '0xbe80fd79e26ce0a605e5d2803e876f1b009d70cc': 2.20359154e-10,
    '0x55c307cbe54a1c1c105838a9d0fd60b75d7ff951': 1.3811117e-11,
    '0x01BaD7E976d59CE92295Dbacd5da7fc06FE05412': 0,
    '0x64be824f732312490224a67537d49b8580068abf': 7.6433702889e-8
  }
]
getScores: 4.923s
```
