### PR TITLE
remove trailing slash

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -272,6 +272,6 @@
     "network": "mainnet",
     "rpc": ["https://rpc.rupx.io"],
     "ws": ["wss://ws.rupx.io"],
-    "explorer": "http://scan.rupx.io/"  
+    "explorer": "http://scan.rupx.io"  
   }
 }


### PR DESCRIPTION
the trailing flash typo display a 404 for users

Fixes # .

Changes proposed in this pull request:
- remove trailing slash
- 
- 
