### PR TITLE
Add a strategy to record 1 vote for a multisig owner/member

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -65,6 +65,7 @@ import { strategy as xcover } from './xcover';
 import { strategy as niuStaked } from './niu-staked';
 import { strategy as mushrooms } from './mushrooms';
 import { strategy as curioCardsErc20Weighted } from './curio-cards-erc20-weighted';
+import { strategy as multisigOwners } from './multisig-owners';
 
 export default {
   balancer,
@@ -132,6 +133,7 @@ export default {
   'ruler-staked-lp': rulerStakedLP,
   xcover,
   'niu-staked': niuStaked,
-  'mushrooms': mushrooms,
-  'curio-cards-erc20-weighted': curioCardsErc20Weighted
+  mushrooms: mushrooms,
+  'curio-cards-erc20-weighted': curioCardsErc20Weighted,
+  'multisig-owners': multisigOwners
 };

--- a/src/strategies/multisig-owners/README.md
+++ b/src/strategies/multisig-owners/README.md
@@ -1,0 +1,6 @@
+# Multisig Strategy
+
+To use this strategy, you would have a multisig contract which has a set of owners. Pass the
+address of that multisig into the params for the strategy. Then, each owner of the multisig will
+have one vote for the strategy. This is great when you have a council of multisig members, where
+each members vote is worth one.

--- a/src/strategies/multisig-owners/examples.json
+++ b/src/strategies/multisig-owners/examples.json
@@ -1,0 +1,20 @@
+[
+    {
+        "name": "Multisig owners",
+        "strategy": {
+            "name": "multisig-owners",
+            "params": {
+                "address": "0x48301Fe520f72994d32eAd72E2B6A8447873CF50"
+            }
+        },
+        "network": "1",
+        "addresses": [
+            "0x47c6c166F462a2886cb45EFeE7FEAf29941ECEb2",
+            "0x65DCD62932fEf5af25AdA91F0F24658e94e259c5",
+            "0x38FA68D1C06BD272893908a74E6BcC67E28d4Da8",
+            "0xE0FADeFDb233C32C67a1e428951aEfE8dF6ce639",
+            "0xE1FDD398329C6b74C14cf19100316f0826a492d3"
+        ],
+        "snapshot": "latest"
+    }
+]

--- a/src/strategies/multisig-owners/index.ts
+++ b/src/strategies/multisig-owners/index.ts
@@ -1,0 +1,50 @@
+import { multicall } from '../../utils';
+
+export const author = 'davekaj';
+export const version = '0.1.0';
+
+const abi = [
+  {
+    constant: true,
+    inputs: [
+      {
+        internalType: 'address',
+        name: 'owner',
+        type: 'address'
+      }
+    ],
+    name: 'isOwner',
+    outputs: [
+      {
+        internalType: 'bool',
+        name: '',
+        type: 'bool'
+      }
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function'
+  }
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const response = await multicall(
+    network,
+    provider,
+    abi,
+    addresses.map((address: any) => [options.address, 'isOwner', [address]]),
+    { blockTag }
+  );
+  console.log('RES: ', response);
+  return Object.fromEntries(
+    response.map((value, i) => [addresses[i], value[0] ? 1 : 0])
+  );
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- Add a strategy to record a single vote as an owner in a multisig wallet

I tried to implement it using `contract-call` but it didn't work because `isOwner()` in the gnosis multisig returns `true`, and not a value. 

I kind of have a feeling some one else might have made a similar strategy to this one. If so , please point me in that direction, and I will just reuse that strategy, and we can close this PR. 

Thank you!