### PR TITLE
Improve support for numerical snapshot block numbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3648,6 +3648,11 @@
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
+    "lodash.tonumber": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
+      "integrity": "sha1-C5azGzVnJ5Prf1pj7nkfG56QJdk="
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "eth-ens-namehash": "^2.0.8",
     "ethereumjs-util": "^7.0.7",
     "json-to-graphql-query": "^2.0.0",
-    "lodash.set": "^4.3.2"
+    "lodash.set": "^4.3.2",
+    "lodash.tonumber": "^4.0.3"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^17.0.0",

--- a/src/plugins/quorum/index.ts
+++ b/src/plugins/quorum/index.ts
@@ -1,15 +1,20 @@
 import { BigNumber } from '@ethersproject/bignumber';
+import toNumber from 'lodash.tonumber';
 import { call } from '../../utils';
 
 export default class Plugin {
   public author = 'lbeder';
-  public version = '0.0.1';
+  public version = '0.1.0';
   public name = 'Quorum';
 
   /**
    * Returns the total voting power at specific snapshot
    */
-  async getTotalVotingPower(web3, quorumOptions, snapshot) {
+  async getTotalVotingPower(
+    web3: any,
+    quorumOptions: any,
+    snapshot: string | Number
+  ) {
     try {
       const { strategy } = quorumOptions;
 
@@ -21,7 +26,9 @@ export default class Plugin {
         case 'balance': {
           const { address, methodABI, decimals } = quorumOptions;
 
-          const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+          const blockTag =
+            snapshot === 'latest' ? snapshot : toNumber(snapshot);
+
           const totalVotingPower = await call(
             web3,
             [methodABI],


### PR DESCRIPTION
Since the Vue plugin may pass the snapshot block number as a string, the standard `typeof snapshot === 'number' ? snapshot : 'latest'` check would've overridden it to `'latest'`. In this PR, this check was improved to check first for an explicit `'latest'` value and try to parse it using `toNumber` otherwise.
