### PR TITLE
chore: add type declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "dist/snapshot.cjs.js",
   "module": "dist/snapshot.esm.js",
   "browser": "dist/snapshot.min.js",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@ensdomains/content-hash": "^2.5.3",
     "@ethersproject/abi": "^5.0.4",


### PR DESCRIPTION
Fixes:

```ts
import snapshot from '@snapshot/snapshot.js'
```

Without type declaration file, import `@snapshot/snapshot.js` directly would cause an error:

```shell
Could not find a declaration file for module '@snapshot-labs/snapshot.js'. 
'/Users/zhouhancheng/code/Maskbook/node_modules/.pnpm/@snapshot-labs/snapshot.js@0.1.7/node_modules/@snapshot-labs/snapshot.js/dist/snapshot.cjs.js' 
implicitly has an 'any' type.
```

