### PR TITLE
Calculate LON shares in xLON contract

### DIFF
--- a/src/strategies/tokenlon/examples.json
+++ b/src/strategies/tokenlon/examples.json
@@ -11,6 +11,7 @@
                 "stakingRewardSushiSwap2": "0x11520d501E10E2E02A2715C4A9d3F8aEb1b72A7A",
                 "stakingRewardUniswap3": "0x74379CEC6a2c9Fde0537e9D9346222a724A278e4",
                 "stakingRewardSushiSwap3": "0x539a67B6f9c3caD58f434CC12624b2d520BC03F8",
+                "xLON": "0xf88506B0F1d30056B9e5580668D5875b9cd30F23",
                 "token": "0x0000000000095413afC295d19EDeb1Ad7B71c952",
                 "decimals": 18
             }

--- a/src/strategies/tokenlon/index.ts
+++ b/src/strategies/tokenlon/index.ts
@@ -115,7 +115,14 @@ export async function strategy(
         options.token,
         'balanceOf',
         [address]
-      ])
+      ]),
+      [options.token, 'balanceOf', [options.xLON]],
+      [options.xLON, 'totalSupply', []],
+      ...addresses.map((address: any) => [
+        options.xLON,
+        'balanceOf',
+        [address]
+      ]),
     ],
     { blockTag }
   );
@@ -180,11 +187,29 @@ export async function strategy(
     addresses.length * 10 + 4,
     addresses.length * 11 + 4
   );
-
+  // LON staked in xLON contract
+  const lonBalanceOfxLON = response.slice(
+    addresses.length * 11 + 4,
+    addresses.length * 11 + 5
+  )[0][0];
+  // xLON total supply
+  const xLONTotalSupply = response.slice(
+    addresses.length * 11 + 5,
+    addresses.length * 11 + 6
+  )[0][0];
+  // user's xLON
+  const xLONBalanceOfUsers = response.slice(
+    addresses.length * 11 + 6,
+    addresses.length * 12 + 6
+  );
   return Object.fromEntries(
     Array(addresses.length)
       .fill('')
       .map((_, i) => {
+        const xLONBalanceOfUser = xLONBalanceOfUsers[i][0];
+        const userLONShares = xLONBalanceOfUser
+          .mul(lonBalanceOfxLON)
+          .div(xLONTotalSupply);
         const lpBalanceUniswap = lpBalancesUniswap[i][0];
         const lpBalanceUniswapStaking2 = lpBalancesUniswapStaking2[i][0];
         const lpBalanceUniswapStaking3 = lpBalancesUniswapStaking3[i][0];
@@ -215,6 +240,7 @@ export async function strategy(
           parseFloat(
             formatUnits(
               tokenBalances[i][0]
+                .add(userLONShares)
                 .add(lonLpBalanceUniswap)
                 .add(lonEarnedBalanceUniswapStaking2)
                 .add(lonEarnedBalanceUniswapStaking3)


### PR DESCRIPTION
Users could gain more LON if they have xLON shares. This PR calculates the voting power of xLON contract.

Relative feature:
https://tokenlon.im/lon/staking

Run tests:
```
npm run test --strategy=tokenlon
```

Result:
```
Strategy: "tokenlon"
Tokenlon
[
  {
    '0x39422F5065cF7968242747Bc19e812B6Ae98B50F': 0,
    '0x3e2764be2a583bab5589223cafabd78c2f9419cf': 59.69314550334276,
    '0x77a6ece6eb5a8d54d1b643f03beebad7e6c6ff06': 20640.785595376157,
    '0x50a01818f24435f965b09ea8fa80826e4355bed5': 16.20886407601014
  }
]
getScores: 5.132s
```
