### PR TITLE
[Urgent] Bug fixes to pob-hash strategy

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -55,7 +55,7 @@ import { strategy as theGraphIndexing } from './the-graph-indexing';
 import { strategy as whitelist } from './whitelist';
 import { strategy as tokenlon } from './tokenlon';
 import { strategy as rebased } from './rebased';
-import { strategy as pobHashCv } from './pob-hash-cv';
+import { strategy as pobHash } from './pob-hash';
 import { strategy as totalAxionShares } from './total-axion-shares';
 import { strategy as erc1155BalanceOf } from './erc1155-balance-of';
 import { strategy as erc1155BalanceOfCv } from './erc1155-balance-of-cv';
@@ -132,7 +132,7 @@ export default {
   whitelist,
   tokenlon,
   rebased,
-  'pob-hash-cv': pobHashCv,
+  'pob-hash': pobHash,
   'total-axion-shares': totalAxionShares,
   'comp-like-votes': compLikeVotes,
   pagination,

--- a/src/strategies/pob-hash/examples.json
+++ b/src/strategies/pob-hash/examples.json
@@ -2,7 +2,7 @@
   {
     "name": "Example query",
     "strategy": {
-      "name": "pob-hash-cv",
+      "name": "pob-hash",
       "params": {
       }
     },
@@ -11,8 +11,9 @@
       "0x0154d25120ed20a516fe43991702e7463c5a6f6e",
       "0x0B7056e2D9064f2ec8647F1ae556BAcc06da6Db4",
       "0xcc5Ddc8CCD5B1E90Bc42F998ec864Ead0090A12B",
-      "0x000000000000000000000000000000000000dead"
+      "0x000000000000000000000000000000000000dead",
+      "0x721931508df2764fd4f70c53da646cb8aed16ace"
     ],
-    "snapshot": 12025413
+    "snapshot": 12208247
   }
 ]


### PR DESCRIPTION
Fixes `pob-hash`:

- Changes subgraph to new subgraph
- Utilizes an address map, to retain original casing of address provided
- Renames to `pob-hash` and removes cv mechanics from strategy
