### PR TITLE
Typo in RSK Testnet rpc server url

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -78,7 +78,7 @@
     "name": "RSK Testnet",
     "chainId": 31,
     "network": "rsk testnet",
-    "rpc": ["hhttps://public-node.testnet.rsk.co"],
+    "rpc": ["https://public-node.testnet.rsk.co"],
     "explorer": "https://explorer.testnet.rsk.co"
   },
   "42": {


### PR DESCRIPTION
Changes proposed in this pull request:
- RPC server for RSK Testnet has a typo, fixing this

