### PR TITLE
fix: update heco mainet rpc url

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -259,7 +259,7 @@
     "network": "testnet",
     "rpc": ["https://http-testnet.hecochain.com"],
     "ws": ["wss://ws-testnet.hecochain.com"],
-    "explorer": "https://scan-testnet.hecochain.com"
+    "explorer": "https://testnet.hecoinfo.com"
   },
   "128": {
     "key": "128",
@@ -267,9 +267,9 @@
     "shortName": "heco",
     "chainId": 128,
     "network": "Mainnet",
-    "rpc": ["https://http-mainnet.hecochain.com"],
-    "ws": ["wss://ws-mainnet.hecochain.com"],
-    "explorer": "https://scan.hecochain.com"
+    "rpc": ["https://mainnet.heco.vote"],
+    "ws": ["wss://ws-mainnet-node.huobichain.com"],
+    "explorer": "https://hecoinfo.com"
   },
   "250": {
     "key": "250",
@@ -288,7 +288,7 @@
     "network": "mainnet",
     "rpc": ["https://rpc.rupx.io"],
     "ws": ["wss://ws.rupx.io"],
-    "explorer": "http://scan.rupx.io"  
+    "explorer": "http://scan.rupx.io"
   },
   "1666600000": {
     "key": "1666600000",


### PR DESCRIPTION
Fixes # .
Since HECO only support ```https://mainnet.heco.vote``` to get archived data, we have to use the vote rpc as snapshot rpc url
Changes proposed in this pull request:
- update heco testnet rpc
- update heco mainnet explorer
- update heco mainnet rpc
- update heco mainnet ws
- update heco mainnet explorer
