### PR TITLE
xSEEN Strategy for seen.haus

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -74,6 +74,7 @@ import { strategy as erc1155AllBalancesOf } from './erc1155-all-balances-of';
 import { strategy as trancheStakingLP } from './tranche-staking-lp';
 import { strategy as masterchefPoolBalance } from './masterchef-pool-balance';
 import { strategy as api } from './api';
+import { strategy as xseen } from './xseen';
 
 export default {
   balancer,
@@ -151,5 +152,6 @@ export default {
   'saffron-finance': saffronFinance,
   'tranche-staking-lp': trancheStakingLP,
   'masterchef-pool-balance': masterchefPoolBalance,
-  api
+  api,
+  xseen,
 };

--- a/src/strategies/xseen/examples.json
+++ b/src/strategies/xseen/examples.json
@@ -12,7 +12,7 @@
     },
     "network": "1",
     "addresses": [
-      "0x8a83716acd66d9e1fb18c9b79540b72e04f80ac0",
+      "0x8a83716acd66d9e1fb18c9b79540b72e04f80ac0"
     ],
     "snapshot": 12328235
   }

--- a/src/strategies/xseen/examples.json
+++ b/src/strategies/xseen/examples.json
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "xSEEN token",
+    "strategy": {
+      "name": "xseen",
+      "params": {
+        "_comment_": "The seen.haus governance token, where xSEEN represents a value of SEEN tokens including rewards.",
+        "tokenAddress": "0x38747baf050d3c22315a761585868dba16abfd89",
+        "symbol": "xSEEN",
+        "decimals": 18
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x8a83716acd66d9e1fb18c9b79540b72e04f80ac0",
+    ],
+    "snapshot": 12328235
+  }
+]

--- a/src/strategies/xseen/index.ts
+++ b/src/strategies/xseen/index.ts
@@ -1,0 +1,89 @@
+import { multicall } from '../../utils';
+
+export const author = 'JayWelsh';
+export const version = '0.1.0';
+
+/**
+ * xSEEN token ABI
+ */
+const xseenAbi = [
+  {
+    constant: true,
+    inputs: [{ internalType: 'address', name: '', type: 'address' }],
+    name: 'balanceOf',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [],
+    name: 'totalSupply',
+    outputs: [{internalType: 'uint256', name: '', type: 'uint256'}],
+    stateMutability: 'view',
+    type: 'function'
+  }
+];
+
+/**
+ * SEEN token ABI
+ */
+ const seenAbi = [
+  {
+    constant: true,
+    inputs: [{ internalType: 'address', name: '', type: 'address' }],
+    name: 'balanceOf',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function'
+  }
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  params,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  const stakingContractSeenBalanceCallParams = [
+    '0xCa3FE04C7Ee111F0bbb02C328c699226aCf9Fd33',
+    'balanceOf',
+    [params.tokenAddress]
+  ]
+
+  const seenRes = await multicall(
+    network,
+    provider,
+    seenAbi,
+    [stakingContractSeenBalanceCallParams],
+    { blockTag }
+  );
+
+  const seenBalanceInStakingContract = seenRes[0];
+
+  const xseenBalanceCallParams = addresses.map((addr) => [
+    params.tokenAddress,
+    'balanceOf',
+    [addr]
+  ]);
+
+  const xseenRes = await multicall(
+    network,
+    provider,
+    xseenAbi,
+    [[params.tokenAddress, 'totalSupply'], ...xseenBalanceCallParams],
+    { blockTag }
+  );
+
+  const totalSupply = xseenRes[0];
+  const balances = xseenRes.slice(1);
+
+  return Object.fromEntries(
+    balances.map((balance, i) => [addresses[i], (balance * (seenBalanceInStakingContract / totalSupply) / 1e18)])
+  );
+}


### PR DESCRIPTION
Changes proposed in this pull request:

Creates strategy to derive the SEEN value from the amount of xSEEN tokens held by an address at the time of the Snapshot

The strategy will be relevant to the https://snapshot.org/#/seen workspace