### PR TITLE
strategies/masterchef-pool-balance: (fix) weight

### DIFF
--- a/src/strategies/masterchef-pool-balance/index.ts
+++ b/src/strategies/masterchef-pool-balance/index.ts
@@ -118,7 +118,7 @@ function processValues(values: any[], options: any): number {
   const weight: BigNumber = BigNumber.from(options.weight || 1);
   let result: BigNumber;
   if (options.uniPairAddress == null) {
-    result = poolStaked;
+    result = poolStaked.mul(weight);
   } else {
     const uniTotalSupply = values[1][0];
     const uniReserve = values[2][0];


### PR DESCRIPTION
strategy didn't multiply by weight when `uniPairAddress` is `null`

Fixes # .

Changes proposed in this pull request:
- fix strategy code
- 
- 
