### PR TITLE
Add support for tokens in Balancer V2 pools

### DIFF
--- a/src/strategies/balancer/examples.json
+++ b/src/strategies/balancer/examples.json
@@ -1,0 +1,40 @@
+[
+  {
+    "name": "Balancer Pool Tokens",
+    "strategy": {
+      "name": "balancer",
+      "params": {
+        "address": "0xba100000625a3754423978a60c9317c58a424e3D",
+        "symbol": "BAL BPT V1+V2",
+        "decimals": 18,
+        "start": 11437840
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0xff052381092420b7f24cc97fded9c0c17b2cbbb9",
+      "0xa478c2975ab1ea89e8196811f51a7b7ade33eb11",
+      "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7",
+      "0x1E1A51E25f2816335cA436D65e9Af7694BE232ad",
+      "0x1F717Ce8ff07597ee7c408b5623dF40AaAf1787C",
+      "0x1c7a9275F2BD5a260A9c31069F77d53473b8ae2e",
+      "0x1d5E65a087eBc3d03a294412E46CE5D6882969f4",
+      "0x1f254336E5c46639A851b9CfC165697150a6c327",
+      "0x2ec3F80BeDA63Ede96BA20375032CDD3aAfb3030",
+      "0x74c3646adad7e196102d1fe35267adfd401a568b",
+      "0x4AcBcA6BE2f8D2540bBF4CA77E45dA0A4a095Fa2",
+      "0x4F3D348a6D09837Ae7961B1E0cEe2cc118cec777",
+      "0x6D7f23A509E212Ba7773EC1b2505d1A134f54fbe",
+      "0x07a1f6fc89223c5ebD4e4ddaE89Ac97629856A0f",
+      "0x8d5F05270da470e015b67Ab5042BDbE2D2FEFB48",
+      "0x8d07D225a769b7Af3A923481E1FdF49180e6A265",
+      "0x8f60501dE5b9b01F9EAf1214dbE1924aA97F7fd0",
+      "0x9B8e8dD9151260c21CB6D7cc59067cd8DF306D58",
+      "0x17ea92D6FfbAA1c7F6B117c1E9D0c88ABdc8b84C",
+      "0x38C0039247A31F3939baE65e953612125cB88268",
+      "0xd109b2a304587569c84308c55465cd9ff0317bfb",
+      "0x1d2c4cd9bee9dfe088430b95d274e765151c32db"
+    ],
+    "snapshot": "latest"
+  }
+]

--- a/src/strategies/balancer/index.ts
+++ b/src/strategies/balancer/index.ts
@@ -5,7 +5,7 @@ export const author = 'bonustrack';
 export const version = '0.1.0';
 
 const BALANCER_SUBGRAPH_URL = {
-  '1': 'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-beta',
+  '1': 'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer',
   '42': 'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-kovan'
 };
 
@@ -45,22 +45,30 @@ export async function strategy(
     // @ts-ignore
     params.poolShares.__args.block = { number: snapshot };
   }
-  const result = await subgraphRequest(BALANCER_SUBGRAPH_URL[network], params);
+
+  // iterate through Balancer V1 & V2 Subgraphs
   const score = {};
-  if (result && result.poolShares) {
-    result.poolShares.forEach((poolShare) =>
-      poolShare.poolId.tokens.map((poolToken) => {
-        const [, tokenAddress] = poolToken.id.split('-');
-        if (tokenAddress === options.address.toLowerCase()) {
-          const userAddress = getAddress(poolShare.userAddress.id);
-          if (!score[userAddress]) score[userAddress] = 0;
-          score[userAddress] =
-            score[userAddress] +
-            (poolToken.balance / poolShare.poolId.totalShares) *
-              poolShare.balance;
-        }
-      })
-    );
+  for (let version = 1; version <= 2; version++) {
+    let versionString = "";
+    if (version == 2) {
+      versionString = "-v2"
+    }
+    const result = await subgraphRequest(BALANCER_SUBGRAPH_URL[network] + versionString, params);
+    if (result && result.poolShares) {
+      result.poolShares.forEach((poolShare) =>
+        poolShare.poolId.tokens.map((poolToken) => {
+          const [, tokenAddress] = poolToken.id.split('-');
+          if (tokenAddress === options.address.toLowerCase()) {
+            const userAddress = getAddress(poolShare.userAddress.id);
+            if (!score[userAddress]) score[userAddress] = 0;
+            score[userAddress] =
+              score[userAddress] +
+              (poolToken.balance / poolShare.poolId.totalShares) *
+                poolShare.balance;
+          }
+        })
+      );
+    }
   }
   return score || {};
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- Add queries to the Balancer V2 subgraph
- Updates V1 subgraph queries to target the "balancer" subgraph instead of the "balancer-beta" one
- Add examples.json to validate balances; the final address in addresses[] has an account with Balancer V2 pool tokens holding BAL