### PR TITLE
increase strategy cap

### DIFF
--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -79,7 +79,7 @@
         "strategies": {
           "type": "array",
           "minItems": 1,
-          "maxItems": 5,
+          "maxItems": 10,
           "items": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
Fixes #229 .

Changes proposed in this pull request:
- Increase the maximum allowed number of strategies from 5 to 10