### PR TITLE
Fix: handle empty results on [decentraland-estate-size]

### DIFF
--- a/src/strategies/decentraland-estate-size/index.ts
+++ b/src/strategies/decentraland-estate-size/index.ts
@@ -51,7 +51,7 @@ export async function strategy(
     );
 
     const nfts = result && result.nfts ? result.nfts : [];
-    for (const estate of result.nfts) {
+    for (const estate of nfts) {
       const userAddress = getAddress(estate.owner.id);
       score[userAddress] =
         (score[userAddress] || 0) + estate.searchEstateSize * multipler;


### PR DESCRIPTION
Handle empty results from the graph