### PR TITLE
[inverse-xinv] Inverse xINV strategy

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -88,6 +88,7 @@ import { strategy as apescape } from './apescape';
 import { strategy as liftkitchen } from './liftkitchen';
 import { strategy as decentralandEstateSize } from './decentraland-estate-size';
 import { strategy as brightid } from './brightid';
+import { strategy as inverseXINV } from './inverse-xinv';
 
 export default {
   balancer,
@@ -179,5 +180,6 @@ export default {
   apescape,
   liftkitchen,
   'decentraland-estate-size': decentralandEstateSize,
-  brightid
+  brightid,
+  'inverse-xinv': inverseXINV,
 };

--- a/src/strategies/inverse-xinv/README.md
+++ b/src/strategies/inverse-xinv/README.md
@@ -1,0 +1,11 @@
+# inverse-xinv
+
+This is a strategy for counting staked INV balance inside of anchor. Referred to as xINV. 
+Here is an example of parameters:
+
+```json
+{
+  "symbol": "xINV",
+  "decimals": 18
+}
+```

--- a/src/strategies/inverse-xinv/examples.json
+++ b/src/strategies/inverse-xinv/examples.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "inverse-xinv",
+      "params": {
+        "symbol": "xINV",
+        "decimals": 18
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x08d816526bdc9d077dd685bd9fa49f58a5ab8e48",
+      "0x3ee505ba316879d246a8fd2b3d7ee63b51b44fab"
+    ],
+    "snapshot": 12511580
+  }
+]

--- a/src/strategies/inverse-xinv/index.ts
+++ b/src/strategies/inverse-xinv/index.ts
@@ -1,0 +1,47 @@
+import { formatUnits, parseUnits } from '@ethersproject/units';
+import { BigNumber } from '@ethersproject/bignumber';
+import { multicall } from '../../utils';
+
+export const author = '0xKiwi';
+export const version = '0.1.0';
+
+const xINV = "0x65b35d6Eb7006e0e607BC54EB2dFD459923476fE";
+const ONE_E18 = parseUnits('1', 18);
+
+const abi = [
+  'function balanceOf(address account) external view returns (uint256)',
+  'function exchangeRateStored() external view returns (uint256)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const exchangeRateResp = await multicall(
+    network, 
+    provider,
+    abi,
+    [[xINV, "exchangeRateStored", []]],
+    { blockTag }
+  );
+  const exchangeRate = exchangeRateResp[0][0];
+
+  const balanceResp = await multicall(
+    network,
+    provider,
+    abi,
+    addresses.map((address: any) => [xINV, 'balanceOf', [address]]),
+    { blockTag }
+  );
+  return Object.fromEntries(
+    balanceResp.map((value, i) => [
+      addresses[i],
+      parseFloat(formatUnits(value[0].mul(exchangeRate).div(ONE_E18).toString(), options.decimals))
+    ])
+  );
+}


### PR DESCRIPTION
This is a PR to add a new strategy to snapshot that allows support for staked INV within Anchor, referred to as xINV.

A good portion of the INV supply is staked in Anchor, so it would be fantastic if this could be added :smiley: 