### PR TITLE
[masterchef-pool-balance] ability to have non integer weights

### DIFF
--- a/src/strategies/masterchef-pool-balance/examples.json
+++ b/src/strategies/masterchef-pool-balance/examples.json
@@ -7,7 +7,8 @@
         "chefAddress": "0xD38abbAeC03a9FF287eFc9a5F0d0580E07335D1D",
         "uniPairAddress": null,
         "pid": "0",
-        "weight": 1
+        "weight": 1,
+        "weightDecimals": 0
       }
     },
     "network": "1",
@@ -25,7 +26,8 @@
         "chefAddress": "0xD38abbAeC03a9FF287eFc9a5F0d0580E07335D1D",
         "uniPairAddress": "0xe0b1433e0174b47e8879ee387f1069a0dbf94137",
         "pid": "1",
-        "weight": 1
+        "weight": 5,
+        "weightDecimals": 1
       }
     },
     "network": "1",

--- a/src/strategies/masterchef-pool-balance/index.ts
+++ b/src/strategies/masterchef-pool-balance/index.ts
@@ -116,15 +116,22 @@ function arrayChunk<T>(arr: T[], chunkSize: number): T[][] {
 function processValues(values: any[], options: any): number {
   const poolStaked = values[0][0];
   const weight: BigNumber = BigNumber.from(options.weight || 1);
+  const weightDecimals: BigNumber = BigNumber.from(10).pow(
+    options.weightDecimals || 0
+  );
   let result: BigNumber;
   if (options.uniPairAddress == null) {
-    result = poolStaked.mul(weight);
+    result = poolStaked.mul(weight).div(weightDecimals);
   } else {
     const uniTotalSupply = values[1][0];
     const uniReserve = values[2][0];
     const precision = BigNumber.from(10).pow(18);
     const tokensPerLp = uniReserve.mul(precision).div(uniTotalSupply);
-    result = poolStaked.mul(tokensPerLp).mul(weight).div(precision);
+    result = poolStaked
+      .mul(tokensPerLp)
+      .mul(weight)
+      .div(weightDecimals)
+      .div(precision);
   }
   return parseFloat(formatUnits(result.toString(), options.decimals || 18));
 }

--- a/src/strategies/masterchef-pool-balance/index.ts
+++ b/src/strategies/masterchef-pool-balance/index.ts
@@ -117,7 +117,7 @@ function processValues(values: any[], options: any): number {
   const poolStaked = values[0][0];
   const weight: BigNumber = BigNumber.from(options.weight || 1);
   const weightDecimals: BigNumber = BigNumber.from(10).pow(
-    options.weightDecimals || 0
+    BigNumber.from(options.weightDecimals || 0)
   );
   let result: BigNumber;
   if (options.uniPairAddress == null) {


### PR DESCRIPTION
Changes proposed in this pull request:

- The `masterchef-pool-balance` strategy could benefit from the use of non integer values. Since `BigNumber` has to be integer we added a `weightDecimals` variable to make final calculations.