### PR TITLE
Add a full sync node for Heco chain

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -275,7 +275,10 @@
     "shortName": "heco",
     "chainId": 128,
     "network": "Mainnet",
-    "rpc": ["https://http-mainnet.hecochain.com"],
+    "rpc": [
+      "https://http-mainnet-node.defibox.com",
+      "https://http-mainnet.hecochain.com"
+    ],
     "ws": ["wss://ws-mainnet-node.huobichain.com"],
     "explorer": "https://hecoinfo.com"
   },


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Current rpc node isn't a full sync node, which will cause ""missing trie node" issue, try this new added node provided by Heco community.
