### PR TITLE
[aave-governance-power] feat: Add Aave Governance strategy

### DIFF
--- a/src/strategies/aave-governance-power/README.md
+++ b/src/strategies/aave-governance-power/README.md
@@ -1,0 +1,11 @@
+# Contract call strategy
+
+Allows to get Voting power or Proposition power from an Aave GovernanceStrategy contract.
+
+## Strategy Parameters
+
+| Param              | Type   | Description                                                                                                                |     |     |
+| ------------------ | ------ | -------------------------------------------------------------------------------------------------------------------------- | --- | --- |
+| governanceStrategy | string | The Ethereum address of the GovernanceStrategy contract to measure voting or proposition power from an address at a block. |     |     |
+| powerType          | string | Use `vote` for Voting Power or `proposition` for Proposition Power                                                         |     |     |
+|                    |        |                                                                                                                            |     |     |

--- a/src/strategies/aave-governance-power/examples.json
+++ b/src/strategies/aave-governance-power/examples.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "Example of Aave Governance Power strategy",
+    "strategy": {
+      "name": "aave-governance-power",
+      "params": {
+        "governanceStrategy": "0xb7e383ef9b1e9189fc0f71fb30af8aa14377429e",
+        "powerType": "vote",
+        "symbol": "Voting Power",
+        "decimals": 18
+      }
+    },
+    "network": "1",
+    "addresses": ["0x5BC928BF0DAb1e4A2ddd9e347b0F22e88026D76c"],
+    "snapshot": 12657715
+  }
+]

--- a/src/strategies/aave-governance-power/index.ts
+++ b/src/strategies/aave-governance-power/index.ts
@@ -1,0 +1,72 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { formatUnits } from '@ethersproject/units';
+import { multicall } from '../../utils';
+
+export const author = 'kartojal';
+export const version = '0.1.0';
+
+/**
+ * Aave Governance strategy to measure voting or
+ */
+
+const abi = [
+  {
+    inputs: [
+      { internalType: 'address', name: 'user', type: 'address' },
+      { internalType: 'uint256', name: 'blockNumber', type: 'uint256' }
+    ],
+    name: 'getPropositionPowerAt',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: 'user', type: 'address' },
+      { internalType: 'uint256', name: 'blockNumber', type: 'uint256' }
+    ],
+    name: 'getVotingPowerAt',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function'
+  }
+];
+
+const powerTypesToMethod = {
+  vote: 'getVotingPowerAt',
+  proposition: 'getPropositionPowerAt'
+};
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  // Early return 0 voting power if governanceStrategy or powerType is not correctly set
+  if (!options.governanceStrategy || !powerTypesToMethod[options.powerType]) {
+    return Object.fromEntries(addresses.map((address, i) => [address, '0']));
+  }
+
+  const response: BigNumber[] = await multicall(
+    network,
+    provider,
+    abi,
+    addresses.map((address: any) => [
+      options.governanceStrategy,
+      powerTypesToMethod[options.powerType],
+      [address.toLowerCase(), snapshot]
+    ]),
+    { blockTag }
+  );
+  return Object.fromEntries(
+    response.map((value, i) => [
+      addresses[i],
+      parseFloat(formatUnits(value.toString(), options.decimals))
+    ])
+  );
+}

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -98,6 +98,7 @@ import { strategy as spookyswap } from './spookyswap';
 import { strategy as rnbwBalance } from './rnbw-balance';
 import { strategy as celerSgnDelegation } from './celer-sgn-delegation';
 import { strategy as balancerDelegation } from './balancer-delegation';
+import { strategy as aaveGovernancePower } from './aave-governance-power';
 
 export default {
   balancer,
@@ -199,5 +200,6 @@ export default {
   spookyswap,
   'rnbw-balance': rnbwBalance,
   'celer-sgn-delegation': celerSgnDelegation,
-  'balancer-delegation': balancerDelegation
+  'balancer-delegation': balancerDelegation,
+  'aave-governance-power': aaveGovernancePower
 };


### PR DESCRIPTION
Changes proposed in this pull request:
- Add a new strategy named `aave-governance-power` for Snapshot to be able to track `Voting power` or `Proposition power` of an address from GovernanceStrategy contract for tracking any governance that derives from an Aave Governance V2 contract.
