### PR TITLE
fix: support "latest" snapshot at aave-governance-power strategy

### DIFF
--- a/src/strategies/aave-governance-power/index.ts
+++ b/src/strategies/aave-governance-power/index.ts
@@ -45,7 +45,7 @@ export async function strategy(
   options,
   snapshot
 ) {
-  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const blockTag = typeof snapshot === 'number' ? snapshot : await provider.getBlockNumber(snapshot);
 
   // Early return 0 voting power if governanceStrategy or powerType is not correctly set
   if (!options.governanceStrategy || !powerTypesToMethod[options.powerType]) {
@@ -59,7 +59,7 @@ export async function strategy(
     addresses.map((address: any) => [
       options.governanceStrategy,
       powerTypesToMethod[options.powerType],
-      [address.toLowerCase(), snapshot]
+      [address.toLowerCase(), blockTag]
     ]),
     { blockTag }
   );


### PR DESCRIPTION
Fixes "Oops, failed to check voting power" when passing "latest"  to the snapshot argument variable at the `aave-governance-power`  strategy.

Changes proposed in this pull request:
- Get block number if "latest" is passed to snapshot argument.
