### PR TITLE
Test cases failing if addresses are different word case

### DIFF
--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -64,7 +64,9 @@ describe(`\nTest strategy "${strategy}"`, () => {
     expect(typeof scores[0]).toBe('object');
     // Check object contains at least one address from example.json
     expect(Object.keys(scores[0]).length).toBeGreaterThanOrEqual(1);
-    expect(Object.keys(scores[0]).some(address => example.addresses.includes(address))).toBe(true);
+    expect(Object.keys(scores[0])
+      .some(address => example.addresses.map(v => v.toLowerCase())
+      .includes(address.toLowerCase()))).toBe(true);
     // Check if all scores are numbers
     expect(Object.values(scores[0]).every((val, i, arr) => typeof val === 'number')).toBe(true)
   });
@@ -108,7 +110,10 @@ describe(`\nTest strategy "${strategy}" with latest snapshot`, () => {
     expect(typeof scores[0]).toBe('object');
     // Check object contains atleast one address from example.json
     expect(Object.keys(scores[0]).length).toBeGreaterThanOrEqual(1);
-    expect(Object.keys(scores[0]).some(address => example.addresses.includes(address))).toBe(true);
+    expect(Object.keys(scores[0])
+      .some(address => example.addresses.map(v => v.toLowerCase())
+      .includes(address.toLowerCase()))).toBe(true);
+
     // Check if all scores are numbers
     expect(Object.values(scores[0]).every((val, i, arr) => typeof val === 'number')).toBe(true)
   });


### PR DESCRIPTION
Fixes issue when running `uniswap` strategy,

where

`0x79317fC0fB17bC0CE213a2B50F343e4D4C277704` is the output 
and `0x79317fc0fb17bc0ce213a2b50f343e4d4c277704` is given in example.json

