### PR TITLE
[eth-with-balance] Add eth-with-balance strategy

### DIFF
--- a/src/strategies/eth-balance/examples.json
+++ b/src/strategies/eth-balance/examples.json
@@ -1,0 +1,33 @@
+[
+    {
+      "name": "Example query",
+      "strategy": {
+        "name": "eth-balance",
+        "params": {     
+        }
+      },
+      "network": "1",
+      "addresses": [
+        "0xa478c2975ab1ea89e8196811f51a7b7ade33eb11",
+        "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7",
+        "0x1E1A51E25f2816335cA436D65e9Af7694BE232ad",
+        "0x1F717Ce8ff07597ee7c408b5623dF40AaAf1787C",
+        "0x1c7a9275F2BD5a260A9c31069F77d53473b8ae2e",
+        "0x1d5E65a087eBc3d03a294412E46CE5D6882969f4",
+        "0x1f254336E5c46639A851b9CfC165697150a6c327",
+        "0x2ec3F80BeDA63Ede96BA20375032CDD3aAfb3030",
+        "0x4AcBcA6BE2f8D2540bBF4CA77E45dA0A4a095Fa2",
+        "0x4F3D348a6D09837Ae7961B1E0cEe2cc118cec777",
+        "0x6D7f23A509E212Ba7773EC1b2505d1A134f54fbe",
+        "0x07a1f6fc89223c5ebD4e4ddaE89Ac97629856A0f",
+        "0x8d5F05270da470e015b67Ab5042BDbE2D2FEFB48",
+        "0x8d07D225a769b7Af3A923481E1FdF49180e6A265",
+        "0x8f60501dE5b9b01F9EAf1214dbE1924aA97F7fd0",
+        "0x9B8e8dD9151260c21CB6D7cc59067cd8DF306D58",
+        "0x17ea92D6FfbAA1c7F6B117c1E9D0c88ABdc8b84C",
+        "0x38C0039247A31F3939baE65e953612125cB88268"
+      ],
+      "snapshot": 11437846
+    }
+  ]
+  

--- a/src/strategies/eth-with-balance/README.md
+++ b/src/strategies/eth-with-balance/README.md
@@ -1,0 +1,9 @@
+# ETH minimum balance strategy
+
+A strategy similar to `erc-20-with-balance`, but for the ETH balance.
+
+Using a low minimum balance, this strategy can be used as a proxy for "active Ethereum address", based on the assumption that active addresses will always have some ETH on them to pay for fees.
+
+# Parameters
+
+`minBalance`: minimum ETH balance required to get voting power of 1.

--- a/src/strategies/eth-with-balance/examples.json
+++ b/src/strategies/eth-with-balance/examples.json
@@ -1,0 +1,34 @@
+[
+    {
+      "name": "Example query",
+      "strategy": {
+        "name": "eth-with-balance",
+        "params": {
+          "minBalance": 0.5
+        }
+      },
+      "network": "1",
+      "addresses": [
+        "0xa478c2975ab1ea89e8196811f51a7b7ade33eb11",
+        "0xeF8305E140ac520225DAf050e2f71d5fBcC543e7",
+        "0x1E1A51E25f2816335cA436D65e9Af7694BE232ad",
+        "0x1F717Ce8ff07597ee7c408b5623dF40AaAf1787C",
+        "0x1c7a9275F2BD5a260A9c31069F77d53473b8ae2e",
+        "0x1d5E65a087eBc3d03a294412E46CE5D6882969f4",
+        "0x1f254336E5c46639A851b9CfC165697150a6c327",
+        "0x2ec3F80BeDA63Ede96BA20375032CDD3aAfb3030",
+        "0x4AcBcA6BE2f8D2540bBF4CA77E45dA0A4a095Fa2",
+        "0x4F3D348a6D09837Ae7961B1E0cEe2cc118cec777",
+        "0x6D7f23A509E212Ba7773EC1b2505d1A134f54fbe",
+        "0x07a1f6fc89223c5ebD4e4ddaE89Ac97629856A0f",
+        "0x8d5F05270da470e015b67Ab5042BDbE2D2FEFB48",
+        "0x8d07D225a769b7Af3A923481E1FdF49180e6A265",
+        "0x8f60501dE5b9b01F9EAf1214dbE1924aA97F7fd0",
+        "0x9B8e8dD9151260c21CB6D7cc59067cd8DF306D58",
+        "0x17ea92D6FfbAA1c7F6B117c1E9D0c88ABdc8b84C",
+        "0x38C0039247A31F3939baE65e953612125cB88268"
+      ],
+      "snapshot": 11437846
+    }
+  ]
+  

--- a/src/strategies/eth-with-balance/index.ts
+++ b/src/strategies/eth-with-balance/index.ts
@@ -1,0 +1,29 @@
+import { strategy as ethBalanceOfStrategy } from '../eth-balance';
+import { verifyResults } from '../ocean-marketplace/oceanUtils';
+
+export const author = 'Aron van Ammers';
+export const version = '0.1.0';
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const score = await ethBalanceOfStrategy(
+    space,
+    network,
+    provider,
+    addresses,
+    options,
+    snapshot
+  );
+  return Object.fromEntries(
+    Object.entries(score).map((address: any) => [
+      address[0],
+      address[1] > (options.minBalance || 0) ? 1 : 0
+    ])
+  );
+}

--- a/src/strategies/eth-with-balance/index.ts
+++ b/src/strategies/eth-with-balance/index.ts
@@ -1,7 +1,6 @@
 import { strategy as ethBalanceOfStrategy } from '../eth-balance';
-import { verifyResults } from '../ocean-marketplace/oceanUtils';
 
-export const author = 'Aron van Ammers';
+export const author = 'AronVanAmmers';
 export const version = '0.1.0';
 
 export async function strategy(

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -12,6 +12,7 @@ import { strategy as erc20BalanceOfQuadraticDelegation } from './erc20-balance-o
 import { strategy as erc20Price } from './erc20-price';
 import { strategy as balanceOfWithMin } from './balance-of-with-min';
 import { strategy as ethBalance } from './eth-balance';
+import { strategy as ethWithBalance } from './eth-with-balance';
 import { strategy as ethWalletAge } from './eth-wallet-age';
 import { strategy as multichain } from './multichain';
 import { strategy as makerDsChief } from './maker-ds-chief';
@@ -124,6 +125,7 @@ export default {
   'erc20-price': erc20Price,
   'balance-of-with-min': balanceOfWithMin,
   'eth-balance': ethBalance,
+  'eth-with-balance': ethWithBalance,
   'eth-wallet-age': ethWalletAge,
   'maker-ds-chief': makerDsChief,
   erc721,


### PR DESCRIPTION
Adds a new strategy `eth-with-balance` which gives a voting power of 1 to any address with a configurable minimum ETH balance.