### PR TITLE
[balancer-smart-pool] update balancer-smart-pool strategy to compare weights to total supply

### DIFF
--- a/src/strategies/balancer-smart-pool/index.ts
+++ b/src/strategies/balancer-smart-pool/index.ts
@@ -1,12 +1,12 @@
+import { formatUnits } from '@ethersproject/units';
 import { strategy as erc20BalanceOfStrategy } from '../erc20-balance-of';
-import { subgraphRequest } from '../../utils';
-
-const BALANCER_SUBGRAPH_URL = {
-  '1': 'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer'
-};
+import { multicall } from '../../utils';
 
 export const author = 'kibagateaux';
 export const version = '0.1.0';
+const abi = [
+  'function totalSupply() public returns (uint256)'
+];
 
 export async function strategy(
   space,
@@ -16,7 +16,7 @@ export async function strategy(
   options,
   snapshot
 ) {
-  const score = await erc20BalanceOfStrategy(
+  const poolShares = await erc20BalanceOfStrategy(
     space,
     network,
     provider,
@@ -24,43 +24,31 @@ export async function strategy(
     options,
     snapshot
   );
-  if (Object.keys(score).length === 0) return {};
+  const poolGovTokens = (await erc20BalanceOfStrategy(
+    space,
+    network,
+    provider,
+    [options.pool],
+    {...options, address: options.governanceToken},
+    snapshot
+  ))[options.pool];
 
-  const poolQueryParams = {
-    pools: {
-      __args: {
-        where: {
-          id: options.pool
-        }
-      },
-      tokens: {
-        __args: {
-          where: {
-            address: options.governanceToken
-          }
-        },
-        balance: true
-      }
-    }
-  };
-  if (snapshot !== 'latest') {
-    // @ts-ignore
-    poolQueryParams.pools.__args.block = { number: snapshot };
-  }
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const totalPoolShares = await multicall(
+    network,
+    provider,
+    abi,
+    [[options.address, 'totalSupply']],
+    { blockTag }
+  )
 
-  const result = await subgraphRequest(
-    BALANCER_SUBGRAPH_URL[network],
-    poolQueryParams
-  );
-  if (!result || !result.pools) return {};
-
-  const totalScore = Object.values(score).reduce((a, b) => a + b, 0);
-  const poolTokenBalance = result.pools[0].tokens[0].balance;
+  if(!totalPoolShares || !poolGovTokens || !Object.keys(poolShares).length) return {}
+  const totalShares = parseFloat(formatUnits(totalPoolShares.toString(), options.decimals))
 
   return Object.fromEntries(
-    Object.entries(score).map((account) => [
+    Object.entries(poolShares).map((account) => [
       account[0],
-      (account[1] / totalScore) * poolTokenBalance
-    ])
-  );
+      (account[1] / totalShares) * poolGovTokens
+    ]
+  ))
 }


### PR DESCRIPTION
Updates #303

I made the assumption that Snapshot had all `addresses` before calling the strategy. This update checks total supply of the pool shares token in the calculation instead of using the sum of shares owned by `addresses`