### PR TITLE
Add new RPC - rpc.ftm.tools for Fantom Opera blockchain

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -347,7 +347,7 @@
     "chainId": 250,
     "network": "Mainnet",
     "multicall": "0x7f6A10218264a22B4309F3896745687E712962a0",
-    "rpc": ["https://rpcapi.fantom.network"],
+    "rpc": ["https://rpc.ftm.tools", "https://rpcapi.fantom.network"],
     "explorer": "https://ftmscan.com"
   },
   "499": {


### PR DESCRIPTION
Introduce additional RPC address for Fantom Opera network.

The new RPC is https://rpc.ftm.tools which is an RPC aggregator, widely used in Fantom Opera project and by Fantom Opera users.

It has become very popular during the high load period on Fantom, which caused the main RPC to lag and fail to respond at all.