### PR TITLE
Fix: don't load chainId from provider

### DIFF
--- a/src/plugins/safeSnap/index.ts
+++ b/src/plugins/safeSnap/index.ts
@@ -278,9 +278,9 @@ export default class Plugin {
     moduleAddress: string,
     transaction: ModuleTransaction
   ) {
-    const provider: StaticJsonRpcProvider = getProvider(network);
+    const chainId = parseInt(network);
     const domain = {
-      chainId: provider.network.chainId,
+      chainId,
       verifyingContract: moduleAddress
     };
     return _TypedDataEncoder.hash(domain, EIP712_TYPES, transaction);
@@ -314,8 +314,9 @@ export default class Plugin {
     transactions: ModuleTransaction[]
   ): Promise<ProposalDetails> {
     const provider: StaticJsonRpcProvider = getProvider(network);
+    const chainId = parseInt(network);
     const txHashes = await this.calcTransactionHashes(
-      provider.network.chainId,
+      chainId,
       moduleAddress,
       transactions
     );


### PR DESCRIPTION
There is an issue that is triggered when loading this page for a second time here: https://snapshot.org/#/samuv.eth/proposal/QmUKuzPSL1zoJxdNVGbHCGvjWKxdQZGpLrR9VWShv4dpqa

On this PR i do a small fix by making the chainId directly available.

![image](https://user-images.githubusercontent.com/16245250/126499093-b05a1be6-1c53-4b6f-a5cb-af7190e8e80a.png)
