### PR TITLE
[erc721-with-tokenid] Add ERC721 with tokenid strategy

### DIFF
--- a/src/strategies/erc721-with-tokenid/README.md
+++ b/src/strategies/erc721-with-tokenid/README.md
@@ -8,6 +8,6 @@ Here is an example of parameters:
 {
   "address": "0x22C1f6050E56d2876009903609a2cC3fEf83B415",
   "symbol": "POAP",
-  "ids": ["613607", "613237"]
+  "tokenIds": ["613607", "613237"]
 }
 ```

--- a/src/strategies/erc721-with-tokenid/README.md
+++ b/src/strategies/erc721-with-tokenid/README.md
@@ -1,0 +1,13 @@
+# erc721 with tokenid
+
+This strategy return the balances of the voters for a specific ERC721 NFT with a given TokenId.
+
+Here is an example of parameters:
+
+```json
+{
+  "address": "0x22C1f6050E56d2876009903609a2cC3fEf83B415",
+  "symbol": "POAP",
+  "ids": ["613607", "613237"]
+}
+```

--- a/src/strategies/erc721-with-tokenid/examples.json
+++ b/src/strategies/erc721-with-tokenid/examples.json
@@ -6,7 +6,7 @@
       "params": {
         "address": "0x22C1f6050E56d2876009903609a2cC3fEf83B415",
         "symbol": "POAP",
-        "ids": ["613607", "613237"]
+        "tokenIds": ["613607", "613237"]
       }
     },
     "network": "1",

--- a/src/strategies/erc721-with-tokenid/examples.json
+++ b/src/strategies/erc721-with-tokenid/examples.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "Example query",
+    "strategy": {
+      "name": "erc721-with-tokenid",
+      "params": {
+        "address": "0x22C1f6050E56d2876009903609a2cC3fEf83B415",
+        "symbol": "POAP",
+        "ids": ["613607", "613237"]
+      }
+    },
+    "network": "1",
+    "addresses": [
+      "0x2b85075702b5bc4737d8e1560b7efe8535105b47",
+      "0x3e17fac953de2cd729b0ace7f6d4353387717e9e",
+      "0xE76Be9C1e10910d6Bc6b63D8031729747910c2f6",
+      "0xC5e1569772b2d425Ac9469d39F17341C01e1CF4c"
+    ],
+    "snapshot": 12913585
+
+  }
+]

--- a/src/strategies/erc721-with-tokenid/index.ts
+++ b/src/strategies/erc721-with-tokenid/index.ts
@@ -23,7 +23,7 @@ export async function strategy(
     options.tokenIds.map( (id: any) => [ options.address, 'ownerOf', [id] ]),
     { blockTag }
   );
-  // return response[0].owner;
+
   return Object.fromEntries(
     addresses.map( (address: any) => [
       address,

--- a/src/strategies/erc721-with-tokenid/index.ts
+++ b/src/strategies/erc721-with-tokenid/index.ts
@@ -1,0 +1,33 @@
+import { multicall } from '../../utils';
+
+export const author = 'dimsome';
+export const version = '0.1.0';
+
+const abi = [
+  'function ownerOf(uint256 tokenId) public view returns (address owner)'
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+  const response = await multicall(
+    network,
+    provider,
+    abi,
+    options.ids.map( (id: any) => [ options.address, 'ownerOf', [id] ]),
+    { blockTag }
+  );
+  // return response[0].owner;
+  return Object.fromEntries(
+    addresses.map( (address: any) => [
+      address,
+      response.findIndex((res: any) => res.owner.toLowerCase() === address.toLowerCase()) > -1 ? 1 : 0,
+    ])
+  );
+}

--- a/src/strategies/erc721-with-tokenid/index.ts
+++ b/src/strategies/erc721-with-tokenid/index.ts
@@ -20,7 +20,7 @@ export async function strategy(
     network,
     provider,
     abi,
-    options.ids.map( (id: any) => [ options.address, 'ownerOf', [id] ]),
+    options.tokenIds.map( (id: any) => [ options.address, 'ownerOf', [id] ]),
     { blockTag }
   );
   // return response[0].owner;

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -92,6 +92,7 @@ import { strategy as molochAll } from './moloch-all';
 import { strategy as molochLoot } from './moloch-loot';
 import { strategy as erc721Enumerable } from './erc721-enumerable';
 import { strategy as erc721WithMultiplier } from './erc721-with-multiplier';
+import { strategy as erc721WithTokenId } from './erc721-with-tokenid';
 import { strategy as hoprUniLpFarm } from './hopr-uni-lp-farm';
 import { strategy as erc721 } from './erc721';
 import { strategy as apescape } from './apescape';
@@ -146,6 +147,7 @@ export default {
   erc721,
   'erc721-enumerable': erc721Enumerable,
   'erc721-with-multiplier': erc721WithMultiplier,
+  'erc721-with-tokenid': erc721WithTokenId,
   'erc1155-balance-of': erc1155BalanceOf,
   'erc1155-balance-of-cv': erc1155BalanceOfCv,
   multichain,


### PR DESCRIPTION
Add Strategy for ERC721 token with a specified tokenId. Useful for POAPs to allow voting with a specified ID rather than all.