### PR TITLE
ReferenceError: TextDecoder is not defined

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "browser": "dist/snapshot.min.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@ensdomains/content-hash": "^2.5.3",
+    "@ensdomains/content-hash": "2.5.3",
     "@ethersproject/abi": "^5.0.4",
     "@ethersproject/address": "^5.0.4",
     "@ethersproject/bignumber": "^5.0.12",


### PR DESCRIPTION
Fixes `ReferenceError: TextDecoder is not defined`

A lot of users reporting this error if npm installs version above `^2.5.3`, this fix will restrict to install only version `2.5.3` where we are not getting this error