### PR TITLE
Add Support for Multicall V2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.3.51",
+  "version": "0.3.52",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.3.52",
+  "version": "0.3.53",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.3.50",
+  "version": "0.3.51",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/networks.json
+++ b/src/networks.json
@@ -5,6 +5,7 @@
     "chainId": 1,
     "network": "homestead",
     "multicall": "0xeefba1e63905ef1d7acba5a8513c70307c1ce441",
+    "multicall2": "0x5ba1e12693dc8f9c48aad8770482f4739beed696",
     "ensResolver": "0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41",
     "rpc": [
       {
@@ -34,6 +35,7 @@
     "network": "ropsten",
     "testnet": true,
     "multicall": "0x53c43764255c17bd724f74c4ef150724ac50a3ed",
+    "multicall2": "0x5ba1e12693dc8f9c48aad8770482f4739beed696",
     "rpc": [
       "https://eth-ropsten.alchemyapi.io/v2/QzGz6gdkpTyDzebi3PjxIaKO7bDTGnSy"
     ],
@@ -49,6 +51,7 @@
     "network": "rinkeby",
     "testnet": true,
     "multicall": "0x42ad527de7d4e9d9d011ac45b31d8551f8fe9821",
+    "multicall2": "0x5ba1e12693dc8f9c48aad8770482f4739beed696",
     "ensResolver": "0xf6305c19e814d2a75429fd637d01f7ee0e77d615",
     "rpc": [
       "https://eth-rinkeby.alchemyapi.io/v2/ugiPEBqMebLQbjro42kalZ1h4StpW_fR",
@@ -69,6 +72,7 @@
     "network": "goerli",
     "testnet": true,
     "multicall": "0x77dca2c955b15e9de4dbbcf1246b4b85b651e50e",
+    "multicall2": "0x5ba1e12693dc8f9c48aad8770482f4739beed696",
     "rpc": [
       "https://eth-goerli.alchemyapi.io/v2/v4nqH_J-J3STit45Mm07TxuYexMHQsYZ"
     ],

--- a/src/networks.json
+++ b/src/networks.json
@@ -13,11 +13,11 @@
         "user": "balancer_user",
         "password": "balancerAnkr20201015"
       },
+      "https://eth-mainnet.alchemyapi.io/v2/4bdDVB5QAaorY2UE-GBUbM2yQB3QJqzv",
       "https://rpc.ankr.com/eth",
       "https://speedy-nodes-nyc.moralis.io/b9aed21e7bb7bdeb35972c9a/eth/mainnet/archive",
       "https://apis.ankr.com/e62bc219f9c9462b8749defe472d2dc5/6106d4a3ec1d1bcc87ec72158f8fd089/eth/archive/main",
       "https://eth-archival.gateway.pokt.network/v1/5f76124fb90218002e9ce985",
-      "https://eth-mainnet.alchemyapi.io/v2/4bdDVB5QAaorY2UE-GBUbM2yQB3QJqzv",
       "https://cloudflare-eth.com"
     ],
     "ws": [

--- a/src/networks.json
+++ b/src/networks.json
@@ -7,12 +7,12 @@
     "multicall": "0xeefba1e63905ef1d7acba5a8513c70307c1ce441",
     "ensResolver": "0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41",
     "rpc": [
-      "https://rpc.ankr.com/eth",
       {
         "url": "https://api-geth-archive.ankr.com",
         "user": "balancer_user",
         "password": "balancerAnkr20201015"
       },
+      "https://rpc.ankr.com/eth",
       "https://speedy-nodes-nyc.moralis.io/b9aed21e7bb7bdeb35972c9a/eth/mainnet/archive",
       "https://apis.ankr.com/e62bc219f9c9462b8749defe472d2dc5/6106d4a3ec1d1bcc87ec72158f8fd089/eth/archive/main",
       "https://eth-archival.gateway.pokt.network/v1/5f76124fb90218002e9ce985",

--- a/src/networks.json
+++ b/src/networks.json
@@ -737,7 +737,7 @@
     "network": "mainnet",
     "multicall": "0x537004440ffFE1D4AE9F009031Fc2b0385FCA9F1",
     "rpc": [
-      "https://rpc.moonriver.moonbeam.network"
+      "https://rpc.api.moonriver.moonbeam.network"
     ],
     "explorer": "https://blockscout.moonriver.moonbeam.network",
     "start": 413539,

--- a/src/utils/multicaller.ts
+++ b/src/utils/multicaller.ts
@@ -1,6 +1,6 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import set from 'lodash.set';
-import { multicall } from '../utils';
+import { multicall, multicall2 } from '../utils';
 
 export default class Multicaller {
   public network: string;
@@ -35,6 +35,22 @@ export default class Multicaller {
       this.provider,
       this.abi,
       this.calls,
+      this.options
+    );
+    result.forEach((r, i) => set(obj, this.paths[i], r.length > 1 ? r : r[0]));
+    this.calls = [];
+    this.paths = [];
+    return obj;
+  }
+
+  async execute2(from?: any, requireSuccess: boolean = true): Promise<any> {
+    const obj = from || {};
+    const result = await multicall2(
+      this.network,
+      this.provider,
+      this.abi,
+      this.calls,
+      requireSuccess,
       this.options
     );
     result.forEach((r, i) => set(obj, this.paths[i], r.length > 1 ? r : r[0]));

--- a/src/utils/multicaller.ts
+++ b/src/utils/multicaller.ts
@@ -43,7 +43,7 @@ export default class Multicaller {
     return obj;
   }
 
-  async execute2(from?: any, requireSuccess: boolean = true): Promise<any> {
+  async execute2(from?: any, requireSuccess = true): Promise<any> {
     const obj = from || {};
     const result = await multicall2(
       this.network,

--- a/test/multicaller.ts
+++ b/test/multicaller.ts
@@ -40,3 +40,26 @@ multi.execute().then((result) => {
   }
   */
 });
+
+multi.execute2(undefined, true).then((result) => {
+  console.log('Multicaller v2 result', result);
+  /* Multicaller result
+  {
+    '0x6B175474E89094C44Da98b954EedeAC495271d0F': {
+      name: 'Dai Stablecoin',
+      symbol: 'DAI',
+      decimals: 18
+    },
+    '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2': {
+      name: 'Wrapped Ether',
+      symbol: 'WETH',
+      decimals: 18
+    },
+    '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599': {
+      name: 'Wrapped BTC',
+      symbol: 'WBTC',
+      decimals: 8
+    }
+  }
+  */
+});


### PR DESCRIPTION
## Overview

This PR adds support for [Makerdao's MulticallV2](https://github.com/makerdao/multicall/blob/master/src/Multicall2.sol).

## Changes Introduced

- MulticallV2 Contracts from MakerDAO's [Multicall Repo](https://github.com/makerdao/multicall) added to [networks.json](https://github.com/snapshot-labs/snapshot.js/blob/master/src/networks.json)
- `execute2` function added to the [Multicaller util](https://github.com/snapshot-labs/snapshot.js/blob/master/src/utils/multicaller.ts) that executes the Multicall V2 [`tryBlockAndAggregate` function](https://github.com/makerdao/multicall/blob/master/src/Multicall2.sol#L67)
- `multicall2` function added to [`utils.ts`](https://github.com/snapshot-labs/snapshot.js/blob/master/src/utils.ts) 
