### PR TITLE
Revert #521

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.3.55",
+  "version": "0.3.54",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/networks.json
+++ b/src/networks.json
@@ -421,7 +421,8 @@
     "multicall": "0xb5b692a88bdfc81ca69dcb1d924f59f0413a602a",
     "rpc": [
       "https://xdai-archive.blockscout.com",
-      "https://poa-xdai.gateway.pokt.network/v1/5f76124fb90218002e9ce985"
+      "https://poa-xdai.gateway.pokt.network/v1/5f76124fb90218002e9ce985",
+      "https://rpc.gnosischain.com"
     ],
     "ws": [
       "wss://rpc.xdaichain.com/wss"

--- a/src/networks.json
+++ b/src/networks.json
@@ -420,7 +420,6 @@
     "network": "mainnet",
     "multicall": "0xb5b692a88bdfc81ca69dcb1d924f59f0413a602a",
     "rpc": [
-      "https://rpc.gnosischain.com",
       "https://xdai-archive.blockscout.com",
       "https://poa-xdai.gateway.pokt.network/v1/5f76124fb90218002e9ce985"
     ],


### PR DESCRIPTION
Reverts snapshot-labs/snapshot.js#521 as node is not a full archive node and `0.3.55` is not released yet