### PR TITLE
Remove format uri because it's causing proposal creation to fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.3.63",
+  "version": "0.3.64",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/schemas/proposal.json
+++ b/src/schemas/proposal.json
@@ -20,7 +20,6 @@
         },
         "discussion": {
           "type": "string",
-          "format": "uri",
           "title": "discussion",
           "maxLength": 256
         },
@@ -66,14 +65,7 @@
           "title": "metadata"
         }
       },
-      "required": [
-        "name",
-        "body",
-        "choices",
-        "snapshot",
-        "start",
-        "end"
-      ],
+      "required": ["name", "body", "choices", "snapshot", "start", "end"],
       "additionalProperties": false
     }
   }


### PR DESCRIPTION
Proposal creation is failing because of format URL. Reverting this change as there doesn't seem to be a way to fix it quickly.
