### PR TITLE
Add customUrl format validation and use for discussion

### DIFF
--- a/src/schemas/proposal.json
+++ b/src/schemas/proposal.json
@@ -20,6 +20,7 @@
         },
         "discussion": {
           "type": "string",
+          "format": "customUrl",
           "title": "discussion",
           "maxLength": 256
         },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -178,7 +178,8 @@ export function validateSchema(schema, data) {
   // @ts-ignore
   addFormats(ajv);
 
-  // Custom URL format
+  // Custom URL format for to allow empty string values
+  // https://github.com/snapshot-labs/snapshot.js/pull/541/files
   ajv.addFormat('customUrl', {
     type: 'string',
     validate: (str) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -173,10 +173,28 @@ export async function getScores(
   }
 }
 
+function isUrl(str) {
+  if (!str.length) return true;
+  return (
+    str.startsWith('http://') ||
+    str.startsWith('https://') ||
+    str.startsWith('ipfs://') ||
+    str.startsWith('ipns://') ||
+    str.startsWith('snapshot://')
+  );
+}
+
 export function validateSchema(schema, data) {
   const ajv = new Ajv({ allErrors: true, allowUnionTypes: true, $data: true });
   // @ts-ignore
   addFormats(ajv);
+
+  // Custom URL format
+  ajv.addFormat('customUrl', {
+    type: 'string',
+    validate: (str) => isUrl(str)
+  });
+
   const validate = ajv.compile(schema);
   const valid = validate(data);
   return valid ? valid : validate.errors;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -178,7 +178,7 @@ export function validateSchema(schema, data) {
   // @ts-ignore
   addFormats(ajv);
 
-  // Custom URL format for to allow empty string values
+  // Custom URL format to allow empty string values
   // https://github.com/snapshot-labs/snapshot.js/pull/541/files
   ajv.addFormat('customUrl', {
     type: 'string',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -173,17 +173,6 @@ export async function getScores(
   }
 }
 
-function isUrl(str) {
-  if (!str.length) return true;
-  return (
-    str.startsWith('http://') ||
-    str.startsWith('https://') ||
-    str.startsWith('ipfs://') ||
-    str.startsWith('ipns://') ||
-    str.startsWith('snapshot://')
-  );
-}
-
 export function validateSchema(schema, data) {
   const ajv = new Ajv({ allErrors: true, allowUnionTypes: true, $data: true });
   // @ts-ignore
@@ -192,7 +181,16 @@ export function validateSchema(schema, data) {
   // Custom URL format
   ajv.addFormat('customUrl', {
     type: 'string',
-    validate: (str) => isUrl(str)
+    validate: (str) => {
+      if (!str.length) return true;
+      return (
+        str.startsWith('http://') ||
+        str.startsWith('https://') ||
+        str.startsWith('ipfs://') ||
+        str.startsWith('ipns://') ||
+        str.startsWith('snapshot://')
+      );
+    }
   });
 
   const validate = ajv.compile(schema);


### PR DESCRIPTION
Fixes bug where we couldn't validate URL and empty string for discussion. Also add some URl types like `snapshot://` that we might want to use in the future.
