### PR TITLE
fix: Supporting 1271 signatures not being 65 bytes long nor rsv compatible

### DIFF
--- a/src/sign/utils.ts
+++ b/src/sign/utils.ts
@@ -9,12 +9,19 @@ export function getHash(data) {
 
 export async function verify(address, sig, data) {
   const { domain, types, message } = data;
-  const recoverAddress = verifyTypedData(domain, types, message, sig);
+
   const hash = getHash(data);
   console.log('Hash', hash);
   console.log('Address', address);
-  console.log('Recover address', recoverAddress);
-  if (address === recoverAddress) return true;
+
+  try {
+    const recoverAddress = verifyTypedData(domain, types, message, sig);
+    console.log('Recover address', recoverAddress);
+    if (address === recoverAddress) return true;
+  } catch (e) {
+    console.log('Could not recoverAddress:' + e.message);
+  }
+
   console.log('Check EIP1271 signature');
   return await verifyEIP1271(address, sig, hash);
 }


### PR DESCRIPTION
Originally, the call to /api/msg would throw "invalid signature string; must be 65 bytes" if the signature has a different length or throw rsv errors, if the 1271 sig is 65 bytes long.

The 1271 signatures of Ambire Wallet have different length and verifying a message would throw errors.

this PR solved this issue, ensuring message verification works on smart wallets like Ambire, Gnosis Safe, Argent, etc