### PR TITLE
fix circular dependencies

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,12 @@ import Client712 from './sign';
 import Client from './client';
 import schemas from './schemas';
 import utils from './utils';
+import voting from './voting';
 
 export default {
   Client,
   Client712,
   schemas,
-  utils
+  utils,
+  voting
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import Client712 from './sign';
 import Client from './client';
 import schemas from './schemas';
 import utils from './utils';
+import validations from './validations';
 import voting from './voting';
 
 export default {
@@ -9,5 +10,6 @@ export default {
   Client712,
   schemas,
   utils,
+  validations,
   voting
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,6 @@ import { signMessage, getBlockNumber } from './utils/web3';
 import { getHash, verify } from './sign/utils';
 import gateways from './gateways.json';
 import networks from './networks.json';
-import voting from './voting';
 
 interface Options {
   url?: string;
@@ -350,7 +349,6 @@ export default {
   clone,
   sleep,
   getNumberWithOrdinal,
-  voting,
   getProvider,
   signMessage,
   getBlockNumber,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,6 @@ import addFormats from 'ajv-formats';
 import Multicaller from './utils/multicaller';
 import { getSnapshots } from './utils/blockfinder';
 import getProvider from './utils/provider';
-import validations from './validations';
 import { signMessage, getBlockNumber } from './utils/web3';
 import { getHash, verify } from './sign/utils';
 import gateways from './gateways.json';
@@ -354,7 +353,6 @@ export default {
   getBlockNumber,
   Multicaller,
   getSnapshots,
-  validations,
   getHash,
   verify,
   SNAPSHOT_SUBGRAPH_URL


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/snapshot.js/issues/544

Changes proposed in this pull request:
- move `voting` and `validation` from `utils` to top-level/index

In the frontend we import from the `src` directory directly (e.g. `'@snapshot-labs/snapshot.js/src/voting/quadratic'`) but score and hub use `snapshot.utils.`. This needs to be adjusted when updating snapshot.js over there. So technically we should bump version to `v1.0.0`.

Probably the remaining circular dependencies should be fixed too.

```
src/utils.ts -> src/utils/multicaller.ts -> src/utils.ts
src/utils.ts -> src/utils/blockfinder.ts -> src/utils.ts
src/utils.ts -> src/sign/utils.ts -> src/sign/eip1271.ts -> src/utils.ts
```

But since this PR already fixes #544 I don't really want to go down that rabbit hole now. Not this month at least.