### PR TITLE
Pass network to provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.4.33",
+  "version": "0.4.34",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -9,7 +9,7 @@ const batchedProviders = {};
 export default function getProvider(network) {
   const url = `https://brovider.xyz/${network}`;
   if (!providers[network])
-    providers[network] = new StaticJsonRpcProvider({ url, timeout: 25000 });
+    providers[network] = new StaticJsonRpcProvider({ url, timeout: 25000 }, Number(network));
   return providers[network];
 }
 


### PR DESCRIPTION
Reference:
https://docs.ethers.io/v5/api/providers/jsonrpc-provider/
> if no network is specified, it will be determined automatically by querying the node using eth_chainId and falling back on eth_networkId.

We already know the network

So this will reduce one call to brovider `eth_chainId` every time someone opens snapshot.org 
![image](https://user-images.githubusercontent.com/15967809/189961668-dfcc0809-ffb3-4ba4-bc72-f5018dad9a54.png)
