### PR TITLE
Add Boba L2 (Avalanche) Network

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -1566,5 +1566,19 @@
     "explorer": "https://turbulent-unique-scheat.explorer.mainnet.skalenodes.com/",
     "start": 401478,
     "logo": "ipfs://QmUdwAZJfyKGZnfPGDsCnNvGu123mdd57kTGj1Y3EWVuWK"
+  },
+  "43288": {
+    "key": "43288",
+    "name": "Boba L2 (Avalanche)",
+    "shortName": "Boba-L2",
+    "chainId": 43288,
+    "network": "mainnet",
+    "multicall": "0x352E11Da7C12EA2440b079A335E67ff9219f6FfB",
+    "rpc": [
+      "https://avax.boba.network"
+    ],
+    "explorer": "https://blockexplorer.avax.boba.network/",
+    "start": 4832,
+    "logo": "ipfs://QmNc7QZFpPDue3Ef4SsuX55RHkqXxUxSyTCpoASeg2hW6d"
   }
 }

--- a/src/networks.json
+++ b/src/networks.json
@@ -1569,8 +1569,8 @@
   },
   "43288": {
     "key": "43288",
-    "name": "Boba L2 (Avalanche)",
-    "shortName": "Boba-L2",
+    "name": "Boba Avax L2",
+    "shortName": "Boba-Avax",
     "chainId": 43288,
     "network": "mainnet",
     "multicall": "0x352E11Da7C12EA2440b079A335E67ff9219f6FfB",
@@ -1579,6 +1579,6 @@
     ],
     "explorer": "https://blockexplorer.avax.boba.network/",
     "start": 4832,
-    "logo": "ipfs://QmNc7QZFpPDue3Ef4SsuX55RHkqXxUxSyTCpoASeg2hW6d"
+    "logo": "ipfs://QmP1iuEynzcghrukQLfw7zh7BJwG3dJSwyZprqD4YHHsFD"
   }
 }

--- a/src/networks.json
+++ b/src/networks.json
@@ -1618,7 +1618,8 @@
     "network": "mainnet",
     "multicall": "0x352E11Da7C12EA2440b079A335E67ff9219f6FfB",
     "rpc": [
-      "https://replica.avax.boba.network"
+      "https://replica.avax.boba.network",
+      "https://avax.boba.network"
     ],
     "explorer": "https://blockexplorer.avax.boba.network/",
     "start": 4832,

--- a/src/networks.json
+++ b/src/networks.json
@@ -1575,7 +1575,7 @@
     "network": "mainnet",
     "multicall": "0x352E11Da7C12EA2440b079A335E67ff9219f6FfB",
     "rpc": [
-      "https://avax.boba.network"
+      "https://replica.avax.boba.network"
     ],
     "explorer": "https://blockexplorer.avax.boba.network/",
     "start": 4832,


### PR DESCRIPTION
Adds Boba's Avalanche L2 to the network list.
Official Docs link: https://docs.boba.network/for-developers/network-avalanche#boba-avalanche-l2-43288-for-the-avalanche-l1-43114