### PR TITLE
Schema update: add aliased to space settings for voting and proposals

### DIFF
--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -157,9 +157,6 @@
             "onlyMembers": {
               "type": "boolean"
             },
-            "aliased": {
-              "type": "boolean"
-            },
             "invalids": {
               "type": "array",
               "items": {

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -157,6 +157,9 @@
             "onlyMembers": {
               "type": "boolean"
             },
+            "aliased": {
+              "type": "boolean"
+            },
             "invalids": {
               "type": "array",
               "items": {
@@ -248,6 +251,9 @@
               "type": "boolean"
             },
             "hideAbstain": {
+              "type": "boolean"
+            },
+            "aliased": {
               "type": "boolean"
             },
             "privacy": {


### PR DESCRIPTION
Partially fixes [2844 for Snapshot](https://github.com/snapshot-labs/snapshot/issues/2844).

**Background**
Currently the actions of creating a new proposal and casting a vote require a signature each time. The goal is to add new space setting enabling using the alias.

A sister PR on snapshot repo will implement the logic in the front end, this one updates the schema for spaces.

**Changes proposed in this pull request:**
- add `aliased: boolean` to `space.voting`


