### PR TITLE
Return choice as valid if choice is encrypted

### DIFF
--- a/src/voting/approval.ts
+++ b/src/voting/approval.ts
@@ -12,7 +12,7 @@ export default class ApprovalVoting {
     votes: ApprovalVote[],
     strategies: Strategy[],
     selected: number[],
-    options: Options = { shutter: false }
+    options: Options = { encryptedChoice: false }
   ) {
     this.proposal = proposal;
     this.votes = votes;
@@ -24,9 +24,13 @@ export default class ApprovalVoting {
   static isValidChoice(
     voteChoice: number[] | string,
     proposalChoices: string[],
-    shutter = false
+    encryptedChoice = false
   ): boolean {
-    if (shutter && typeof voteChoice === 'string' && voteChoice.length > 0) {
+    if (
+      encryptedChoice &&
+      typeof voteChoice === 'string' &&
+      voteChoice.length > 0
+    ) {
       return true;
     }
     return (
@@ -49,7 +53,7 @@ export default class ApprovalVoting {
       ApprovalVoting.isValidChoice(
         vote.choice,
         this.proposal.choices,
-        this.options.shutter
+        this.options.encryptedChoice
       )
     );
   }

--- a/src/voting/quadratic.ts
+++ b/src/voting/quadratic.ts
@@ -42,7 +42,7 @@ export default class QuadraticVoting {
     votes: QuadraticVote[],
     strategies: Strategy[],
     selected: QuadraticChoice,
-    options: Options = { shutter: false }
+    options: Options = { encryptedChoice: false }
   ) {
     this.proposal = proposal;
     this.votes = votes;
@@ -54,9 +54,13 @@ export default class QuadraticVoting {
   static isValidChoice(
     voteChoice: QuadraticChoice | string,
     proposalChoices: string[],
-    shutter = false
+    encryptedChoice = false
   ): boolean {
-    if (shutter && typeof voteChoice === 'string' && voteChoice.length > 0) {
+    if (
+      encryptedChoice &&
+      typeof voteChoice === 'string' &&
+      voteChoice.length > 0
+    ) {
       return true;
     }
     return (
@@ -85,7 +89,7 @@ export default class QuadraticVoting {
       QuadraticVoting.isValidChoice(
         vote.choice,
         this.proposal.choices,
-        this.options.shutter
+        this.options.encryptedChoice
       )
     );
   }

--- a/src/voting/rankedChoice.ts
+++ b/src/voting/rankedChoice.ts
@@ -89,7 +89,7 @@ export default class RankedChoiceVoting {
     votes: RankedChoiceVote[],
     strategies: Strategy[],
     selected: number[],
-    options: Options = { shutter: false }
+    options: Options = { encryptedChoice: false }
   ) {
     this.proposal = proposal;
     this.votes = votes;
@@ -101,9 +101,13 @@ export default class RankedChoiceVoting {
   static isValidChoice(
     voteChoice: number[] | string,
     proposalChoices: string[],
-    shutter = false
+    encryptedChoice = false
   ): boolean {
-    if (shutter && typeof voteChoice === 'string' && voteChoice.length > 0) {
+    if (
+      encryptedChoice &&
+      typeof voteChoice === 'string' &&
+      voteChoice.length > 0
+    ) {
       return true;
     }
     return (
@@ -127,7 +131,7 @@ export default class RankedChoiceVoting {
       RankedChoiceVoting.isValidChoice(
         vote.choice,
         this.proposal.choices,
-        this.options.shutter
+        this.options.encryptedChoice
       )
     );
   }

--- a/src/voting/singleChoice.ts
+++ b/src/voting/singleChoice.ts
@@ -12,7 +12,7 @@ export default class SingleChoiceVoting {
     votes: SingleChoiceVote[],
     strategies: Strategy[],
     selected: number,
-    options: Options = { shutter: false }
+    options: Options = { encryptedChoice: false }
   ) {
     this.proposal = proposal;
     this.votes = votes;
@@ -24,9 +24,13 @@ export default class SingleChoiceVoting {
   static isValidChoice(
     voteChoice: number | string,
     proposalChoices: string[],
-    shutter = false
+    encryptedChoice = false
   ): boolean {
-    if (shutter && typeof voteChoice === 'string' && voteChoice.length > 0) {
+    if (
+      encryptedChoice &&
+      typeof voteChoice === 'string' &&
+      voteChoice.length > 0
+    ) {
       return true;
     }
     return (
@@ -40,7 +44,7 @@ export default class SingleChoiceVoting {
       SingleChoiceVoting.isValidChoice(
         vote.choice,
         this.proposal.choices,
-        this.options.shutter
+        this.options.encryptedChoice
       )
     );
   }

--- a/src/voting/types.ts
+++ b/src/voting/types.ts
@@ -39,5 +39,5 @@ export interface WeightedVote {
 }
 
 export interface Options {
-  shutter: boolean;
+  encryptedChoice: boolean;
 }

--- a/src/voting/weighted.ts
+++ b/src/voting/weighted.ts
@@ -24,7 +24,7 @@ export default class WeightedVoting {
     votes: WeightedVote[],
     strategies: Strategy[],
     selected: { [key: string]: number },
-    options: Options = { shutter: false }
+    options: Options = { encryptedChoice: false }
   ) {
     this.proposal = proposal;
     this.votes = votes;
@@ -36,9 +36,13 @@ export default class WeightedVoting {
   static isValidChoice(
     voteChoice: { [key: string]: number } | string,
     proposalChoices: string[],
-    shutter = false
+    encryptedChoice = false
   ): boolean {
-    if (shutter && typeof voteChoice === 'string' && voteChoice.length > 0) {
+    if (
+      encryptedChoice &&
+      typeof voteChoice === 'string' &&
+      voteChoice.length > 0
+    ) {
       return true;
     }
     return (


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/snapshot/issues/3234
Sequencer changes: https://github.com/snapshot-labs/snapshot-sequencer/pull/23

------
- Accepts new param if a choice is encrypted or not
- If the choice is encrypted, count it as a valid choice
- else continue doing the same as before
- In the sequencer, if the shutter is enabled and the proposal is active, we pass true, else false

TODO:
- [ ] Test everything once again
- [ ] Test all voting types