### PR TITLE
Moonbeam: update explorer url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.4.73",
+  "version": "0.4.74",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/networks.json
+++ b/src/networks.json
@@ -1060,7 +1060,7 @@
       "https://rpc.api.moonbeam.network"
     ],
     "explorer": {
-      "url": "https://blockscout.moonbeam.network"
+      "url": "https://moonscan.io/"
     },
     "start": 171135,
     "logo": "ipfs://QmWKTEK2pj5sBBbHnMHQbWgw6euVdBrk2Ligpi2chrWASk"


### PR DESCRIPTION
Following the request from Moonbeam team to update their explorer url 🙏


<img width="440" alt="image" src="https://user-images.githubusercontent.com/39556343/227158024-a7af6ef0-c2e3-484e-be8c-a36b7b8f2e6c.png">
