### PR TITLE
Turn on GZip compression by default

### DIFF
--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -25,9 +25,9 @@ export function getBatchedProvider(network) {
   if (!batchedProviders[network])
     batchedProviders[network] = new JsonRpcBatchProvider(
       {
-        allowGzip: true,
-        url: url,
-        timeout: 25000
+        url,
+        timeout: 25000,
+        allowGzip: true
       });
   return batchedProviders[network];
 }

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -11,9 +11,9 @@ export default function getProvider(network) {
   if (!providers[network])
     providers[network] = new StaticJsonRpcProvider(
       {
-        allowGzip: true,
-        url: url,
-        timeout: 25000
+        url,
+        timeout: 25000,
+        allowGzip: true
       },
       Number(network)
     );

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -10,7 +10,11 @@ export default function getProvider(network) {
   const url = `https://rpc.snapshot.org/${network}`;
   if (!providers[network])
     providers[network] = new StaticJsonRpcProvider(
-      { url, timeout: 25000 },
+      {
+        allowGzip: "true",
+        url: url,
+        timeout: 25000
+      },
       Number(network)
     );
   return providers[network];
@@ -19,9 +23,11 @@ export default function getProvider(network) {
 export function getBatchedProvider(network) {
   const url = `https://rpc.snapshot.org/${network}`;
   if (!batchedProviders[network])
-    batchedProviders[network] = new JsonRpcBatchProvider({
-      url,
-      timeout: 25000
-    });
+    batchedProviders[network] = new JsonRpcBatchProvider(
+      {
+        allowGzip: "true",
+        url: url,
+        timeout: 25000
+      });
   return batchedProviders[network];
 }

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -11,7 +11,7 @@ export default function getProvider(network) {
   if (!providers[network])
     providers[network] = new StaticJsonRpcProvider(
       {
-        allowGzip: "true",
+        allowGzip: true,
         url: url,
         timeout: 25000
       },
@@ -25,7 +25,7 @@ export function getBatchedProvider(network) {
   if (!batchedProviders[network])
     batchedProviders[network] = new JsonRpcBatchProvider(
       {
-        allowGzip: "true",
+        allowGzip: true,
         url: url,
         timeout: 25000
       });


### PR DESCRIPTION
Fixes #810.

Changes proposed in this pull request:
- Turn on GZip compression by default for all requests by all Providers.
