### PR TITLE
refactor: reuse ajv instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.4.77",
+  "version": "0.4.78",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",


### PR DESCRIPTION
Creating ajv instance is expensive, around ~11ms of synchronous execution on my machine. This is where most of `validateSchema`'s runtime is spent, which is executed twice per vote, resulting in 22ms of execution time spent creating fresh ajv instances on every vote.

Reusing ajv instance lowers validation time to ~0.02ms, 500x improvement.

It makes sense to precompute `.compile` as well, but those improvements seem negligible in our current usage.