### PR TITLE
Added Linea Goerli testnet (ChainID: 59140 ) to networks.json

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -1749,7 +1749,7 @@
     "explorer": {
       "url": "https://gwscan.com"
     },
-    "start": 15034,
+    "start": 15034, 
     "logo": "ipfs://QmR6Q2CTds6Uwu8Euo7BKvFKAeg1AyVSxWzqCvyquDD7NF"
   },
   "80001": {
@@ -2190,5 +2190,22 @@
     },
     "start": 501318,
     "logo": "ipfs://QmYz8LK5WkUN8UwqKfWUjnyLuYqQZWihT7J766YXft4TSy"
+  },
+  "59140": {
+    "key": "59140",
+    "name": "Linea Goerli test network",
+    "shortName": "Linea Goerli",
+    "chainId": 59140,
+    "network": "testnet",
+    "testnet": true,
+    "multicall": "0xcA11bde05977b3631167028862bE2a173976CA11",
+    "rpc": [
+      "https://rpc.goerli.linea.build"
+    ],
+    "explorer": {
+      "url": "https://explorer.goerli.linea.build"
+    },
+    "start": 1,
+    "logo": "ipfs://QmSwCnEeLoyMApQd1YfhmGvLt97bH5mLPoabjKqUSuQHHF" 
   }
 }


### PR DESCRIPTION
tested on https://snapshot-networks.on.fleek.co/
last block fetched correctly
no error messages

Fixes # .

Changes proposed in this pull request:
- 
- 
- 
