### PR TITLE
feat: Add space delegation portal schema

### DIFF
--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -237,8 +237,8 @@
         "delegationPortal": {
           "delegationType": {
             "type": "string",
-            "title": "Standard",
-            "description": "The standard used by your delegation contract",
+            "title": "Delegation type",
+            "description": "Specify the type of delegation that you are using",
             "anyOf": [
               { "const": "compound-governor", "title": "Compound governor" }
             ]

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -253,8 +253,8 @@
           "delegationApi": {
             "type": "string",
             "format": "uri",
-            "title": "Subgraph URL",
-            "description": "The URL of your delegation subgraph",
+            "title": "Delegation API",
+            "description": "The URL of your delegation API (e.g a subgraph)",
             "examples": [
               "https://api.thegraph.com/subgraphs/name/arr00/uniswap-governance-v2"
             ]

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -235,7 +235,7 @@
           "additionalProperties": false
         },
         "delegationPortal": {
-          "standard": {
+          "delegationType": {
             "type": "string",
             "title": "Standard",
             "description": "The standard used by your delegation contract",
@@ -243,14 +243,14 @@
               { "const": "compound-governor", "title": "Compound governor" }
             ]
           },
-          "contract": {
+          "delegationContract": {
             "type": "string",
             "format": "address",
             "title": "Contract address",
             "description": "The address of your delegation contract",
             "examples": ["0x3901D0fDe202aF1427216b79f5243f8A022d68cf"]
           },
-          "subgraphUrl": {
+          "delegationApi": {
             "type": "string",
             "format": "uri",
             "title": "Subgraph URL",

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -234,8 +234,31 @@
           "required": ["name"],
           "additionalProperties": false
         },
-        "delegation": {
-          "type": "boolean"
+        "delegationPortal": {
+          "standard": {
+            "type": "string",
+            "title": "Standard",
+            "description": "The standard used by your delegation contract",
+            "anyOf": [
+              { "const": "compound-governor", "title": "Compound governor" }
+            ]
+          },
+          "contract": {
+            "type": "string",
+            "format": "address",
+            "title": "Contract address",
+            "description": "The address of your delegation contract",
+            "examples": ["0x3901D0fDe202aF1427216b79f5243f8A022d68cf"]
+          },
+          "subgraphUrl": {
+            "type": "string",
+            "format": "uri",
+            "title": "Subgraph URL",
+            "description": "The URL of your delegation subgraph",
+            "examples": [
+              "https://api.thegraph.com/subgraphs/name/arr00/uniswap-governance-v2"
+            ]
+          }
         },
         "allowAlias": {
           "type": "boolean"


### PR DESCRIPTION
The `delegation` wasn't used are far as I can tell, so I removed it as well.