### PR TITLE
Add Evmos Testnet and Mainnet

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -2297,7 +2297,7 @@
       "wss://eth.bd.evmos.org:8546"
     ],
     "explorer": {
-      "url": "https://escan.live/"
+      "url": "https://escan.live"
     },
     "start": 13959539,
     "logo": "ipfs://QmVgkQTA8cbYMijWS8AN44xzwAEQvFc2dCpih1qK78ZRQW"

--- a/src/networks.json
+++ b/src/networks.json
@@ -2277,7 +2277,7 @@
       "wss://eth.bd.evmos.dev:8546"
     ],
     "explorer": {
-      "url": "https://testnet.escan.live/"
+      "url": "https://testnet.escan.live"
     },
     "start": 14929860,
     "logo": "ipfs://QmVgkQTA8cbYMijWS8AN44xzwAEQvFc2dCpih1qK78ZRQW"

--- a/src/networks.json
+++ b/src/networks.json
@@ -2111,11 +2111,11 @@
     "start": 43317,
     "logo": "ipfs://QmXvum7SNVaAqAc2jNzR1NpNZN1GGvNaKWydg8a1GEDQ7y"
   },
-  "9000": {
-    "key": "9000",
+  "6102": {
+    "key": "6102",
     "name": "Cascadia Testnet",
     "shortName": "Cascadia",
-    "chainId": 9000,
+    "chainId": 6102,
     "network": "testnet",
     "multicall": "0xBd186aca63bD4f5f4eC9E98028461A6A94ac4a12",
     "rpc": [
@@ -2222,5 +2222,45 @@
     },
     "start": 498623,
     "logo": "ipfs://QmSwCnEeLoyMApQd1YfhmGvLt97bH5mLPoabjKqUSuQHHF"
+  },
+  "9000": {
+    "key": "9000",
+    "name": "Evmos Network Testnet",
+    "shortName": "Evmos Testnet",
+    "chainId": 9000,
+    "network": "testnet",
+    "testnet": true,
+    "multicall": "0xbf84d77eb467c4aaa2988ac070cd119984c0aaa2",
+    "rpc": [
+      "https://eth.bd.evmos.dev:8545"
+    ],
+    "ws": [
+      "wss://eth.bd.evmos.dev:8546"
+    ],
+    "explorer": {
+      "url": "https://testnet.escan.live/"
+    },
+    "start": 14929860,
+    "logo": "ipfs://QmVgkQTA8cbYMijWS8AN44xzwAEQvFc2dCpih1qK78ZRQW"
+  },
+  "9001": {
+    "key": "9001",
+    "name": "Evmos Network",
+    "shortName": "Evmos",
+    "chainId": 9001,
+    "network": "mainnet",
+    "testnet": false,
+    "multicall": "0x37763d16f8dBf6F185368E0f256350cAb7E24b26",
+    "rpc": [
+      "https://eth.bd.evmos.org:8545"
+    ],
+    "ws": [
+      "wss://eth.bd.evmos.org:8546"
+    ],
+    "explorer": {
+      "url": "https://escan.live/"
+    },
+    "start": 13959539,
+    "logo": "ipfs://QmVgkQTA8cbYMijWS8AN44xzwAEQvFc2dCpih1qK78ZRQW"
   }
 }


### PR DESCRIPTION
- Added Evmos testnet and mainnet
- Note: block height does not start at 1 (security hardfork at launch)
- Cascadia's testnet chainID is incorrect (fork of Evmos)
- Changed Cascadia's testnet chainid thats listed on other block explorers
- Multicall contracts verified on Sourcify