### PR TITLE
Added Findora network

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -2248,7 +2248,7 @@
   },
   "59140": {
     "key": "59140",
-    "name": "Linea Goerli test network",
+    "name": "Linea Goerli testnet",
     "shortName": "Linea Goerli",
     "chainId": 59140,
     "network": "testnet",

--- a/src/networks.json
+++ b/src/networks.json
@@ -1291,6 +1291,22 @@
     "start": 94085,
     "logo": "ipfs://QmaQxfwpXYTomUd24PMx5tKjosupXcm99z1jL1XLq9LWBS"
   },
+  "2152": {
+    "key": "2152",
+    "name": "Findora Mainnet",
+    "shortName": "Findora",
+    "chainId": 2152,
+    "network": "mainnet",
+    "multicall": "0x319E6CCaA89C3dCe65946E759a32a09531E6b72f",
+    "rpc": [
+      "https://archive.prod.findora.org:8545/"
+    ],
+    "explorer": {
+      "url": "https://evm.findorascan.io"
+    },
+    "start": 3378569,
+    "logo": "ipfs://QmXkneyRB6HbHTHRLCZpZqSsawiyJY7b2kZ2V8ydvKYAgv"
+  },
   "2400": {
     "key": "2400",
     "name": "TCG Verse Mainnet",

--- a/src/networks.json
+++ b/src/networks.json
@@ -1297,14 +1297,14 @@
     "shortName": "Findora",
     "chainId": 2152,
     "network": "mainnet",
-    "multicall": "0x319E6CCaA89C3dCe65946E759a32a09531E6b72f",
+    "multicall": "0xCF7D1e21CBe9bdEF235aef06C5d8051B3d4DF0f5",
     "rpc": [
       "https://archive.prod.findora.org:8545/"
     ],
     "explorer": {
       "url": "https://evm.findorascan.io"
     },
-    "start": 3378569,
+    "start": 4219343,
     "logo": "ipfs://QmXkneyRB6HbHTHRLCZpZqSsawiyJY7b2kZ2V8ydvKYAgv"
   },
   "2400": {


### PR DESCRIPTION
Changes proposed in this pull request:

1. Added Findora mainnet
2. The previous PR: https://github.com/snapshot-labs/snapshot.js/pull/786
3. Fixed the last remaining issue, the NODE LIMIT (see test result in the screenshot attached) is now > 500
![2152_test](https://github.com/snapshot-labs/snapshot.js/assets/34498985/848f2c89-5419-47eb-abdb-f7b0b5f8d2c0)

Hi, @ChaituVR, I wanted to express my gratitude for your continuous technical support throughout this process. We have invested significant engineering efforts and successfully resolved the final NODE LIMIT issue. As per our previous conversation, I was hoping you could assist us by merging the PR now that it's been addressed.