### PR TITLE
Gnosis - replace with working explorer endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.4.104",
+  "version": "0.4.105",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/networks.json
+++ b/src/networks.json
@@ -566,7 +566,7 @@
       "wss://rpc.xdaichain.com/wss"
     ],
     "explorer": {
-      "url": "https://blockscout.com/poa/xdai"
+      "url": "https://gnosis.blockscout.com/api"
     },
     "start": 4108192,
     "logo": "ipfs://QmZeiy8Ax4133wzxUQM9ky8z5XFVf6YLFjJMmTWbWVniZR"

--- a/src/networks.json
+++ b/src/networks.json
@@ -566,7 +566,7 @@
       "wss://rpc.xdaichain.com/wss"
     ],
     "explorer": {
-      "url": "https://gnosis.blockscout.com/api"
+      "url": "https://gnosis.blockscout.com"
     },
     "start": 4108192,
     "logo": "ipfs://QmZeiy8Ax4133wzxUQM9ky8z5XFVf6YLFjJMmTWbWVniZR"


### PR DESCRIPTION
Related to [4063](https://github.com/snapshot-labs/snapshot/pull/4063), follows up the explorer url change.