### PR TITLE
Update Chain ID Shimmer EVM Testnet in networks.json

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -2394,7 +2394,7 @@
     "explorer": {
       "url": "https://explorer.palm-uat.xyz/"
     },
-    "start": 7282345,
+    "start": 10614,
     "logo": "ipfs://QmRHB9TqMdVHY392vYiv8sTJ7VHShkq5FT6nS9fPuUNBf1"
   }
 }

--- a/src/networks.json
+++ b/src/networks.json
@@ -1204,7 +1204,7 @@
     "testnet": true,
     "multicall": "0x751d21047C116413895c259f3f305e38C10B7cF6",
     "rpc": [
-      "https://json-rpc.evm.testnet.shimmer.network/"
+      "https://archive.evm.testnet.shimmer.network/v1/chains/rms1pr75wa5xuepg2hew44vnr28wz5h6n6x99zptk2g68sp2wuu2karywgrztx3/evm"
     ],
     "explorer": {
       "url": "https://explorer.evm.testnet.shimmer.network/"

--- a/src/networks.json
+++ b/src/networks.json
@@ -1195,14 +1195,14 @@
     },
     "logo": "ipfs://QmVH3uyPQDcrPC1DMUWCb7HayMv1oMAiKehuWwP2C2fdgM"
   },
-  "1071": {
-    "key": "1071",
+  "1072": {
+    "key": "1072",
     "name": "Shimmer EVM Testnet",
     "shortName": "ShimmerEVM",
-    "chainId": 1071,
+    "chainId": 1072,
     "network": "testnet",
     "testnet": true,
-    "multicall": "0xb6d9a0849bA7a6FB565567A6013cFEb8d91A1688",
+    "multicall": "0x751d21047C116413895c259f3f305e38C10B7cF6",
     "rpc": [
       "https://json-rpc.evm.testnet.shimmer.network/"
     ],

--- a/src/networks.json
+++ b/src/networks.json
@@ -1209,7 +1209,7 @@
     "explorer": {
       "url": "https://explorer.evm.testnet.shimmer.network/"
     },
-    "start": 38066,
+    "start": 10614,
     "logo": "ipfs://QmYGxmEhV6djksUk97pdE9TmL6DXm9KW8BP7pwUv8pqp8r"
   },
   "1088": {
@@ -2407,7 +2407,7 @@
     "explorer": {
       "url": "https://explorer.palm-uat.xyz/"
     },
-    "start": 10614,
+    "start": 7282345,
     "logo": "ipfs://QmRHB9TqMdVHY392vYiv8sTJ7VHShkq5FT6nS9fPuUNBf1"
   }
 }


### PR DESCRIPTION
The Testnet was reset and moved to Chain ID 1072. ID 1071 does not exist any longer. Submitted new Chain ID and Multical contract

Fixes # .

Changes proposed in this pull request:
-  new Chain ID
- new Multicall contract
- 
