### PR TITLE
Add: Neon Devnet and Neon Mainnet

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -2293,6 +2293,38 @@
     "start": 751532,
     "logo": "ipfs://QmR2UYZczmYa4s8mr9HZHci5AQwyAnwUW7tSUZz7KWF3sA"
   },
+  "245022926": {
+    "key": "245022926",
+    "name": "Neon Devnet",
+    "chainId": 245022926,
+    "network": "testnet",
+    "testnet": true,
+    "multicall": "0xcA11bde05977b3631167028862bE2a173976CA11",
+    "rpc": [
+      "https://devnet.neonevm.org"
+    ],
+    "explorer": {
+      "url": "https://devnet.neonscan.org/"
+    },
+    "start": 177706109,
+    "logo": "ipfs://QmecRPQGa4bU7tybg1sUQY48Md9rWnmhrT6WW5ueqvhg6P"
+  },
+  "245022934": {
+    "key": "245022934",
+    "name": "Neon",
+    "chainId": 245022934,
+    "network": "mainnet",
+    "testnet": false,
+    "multicall": "0xcA11bde05977b3631167028862bE2a173976CA11",
+    "rpc": [
+      "https://neon-proxy-mainnet.solana.p2p.org"
+    ],
+    "explorer": {
+      "url": "https://neonscan.org/"
+    },
+    "start": 197214559,
+    "logo": "ipfs://QmecRPQGa4bU7tybg1sUQY48Md9rWnmhrT6WW5ueqvhg6P"
+  },
   "278611351": {
     "key": "278611351",
     "name": "Razor SKALE Chain",


### PR DESCRIPTION
This PR adds the Neon Devnet and Mainnet to Snapshot

Neon EVM was launched to public on 17th July 2023 during ETHCC

References:
Mainnet: https://chainlist.org/chain/245022934
Devnet: https://chainlist.org/chain/245022926

