### PR TITLE
Fallback to relayer if signature is 0x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.4.110",
+  "version": "0.5.0",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -77,7 +77,6 @@ export default class Client {
 
   async send(envelop) {
     let address = this.address;
-    console.log('sig', envelop.sig);
     if (envelop.sig === '0x' && this.options.relayerURL)
       address = this.options.relayerURL;
     const init = {


### PR DESCRIPTION
- If signature is `0x` , it will use relayer instead of sequencer
- Should not break anything with existing flow