### PR TITLE
fix: handle JSON-RPC errors from score-api

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -238,6 +238,11 @@ export async function getScores(
       body: JSON.stringify({ params })
     });
     const obj = await res.json();
+
+    if (obj.error) {
+      return Promise.reject(obj.error);
+    }
+
     return options.returnValue === 'all'
       ? obj.result
       : obj.result[options.returnValue || 'scores'];

--- a/test/e2e/utils/getScores.spec.ts
+++ b/test/e2e/utils/getScores.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect, describe } from 'vitest';
+import { getScores } from '../../../src/utils';
+
+describe('test getScores', () => {
+  test('getScores should returns a promise rejection on error from score-api', async () => {
+    expect.assertions(1);
+    await expect(
+      getScores('test.eth', [], '1', ['0x0'])
+    ).to.rejects.toHaveProperty('code');
+  });
+});


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

The `getScores` function does not take into account when the score-api is returning a json-rpc error object.

## 💊 Fixes / Solution

Handle case when score-api is returning a json-rpc error object.

## 🚧 Changes

- Add an `if` condition to return a promise rejection with the json-rpc error object when present.

## 🛠️ Tests

- Trigger the `getScores` function with dummy data, which will be handled and rejected by score-api
- It should return a promise rejection, with the JSON-RPC error object