### PR TITLE
fix: return the same json error on network error

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -247,6 +247,9 @@ export async function getScores(
       ? obj.result
       : obj.result[options.returnValue || 'scores'];
   } catch (e) {
+    if (e.errno) {
+      return Promise.reject({ code: e.errno, message: e.toString(), data: '' });
+    }
     return Promise.reject(e);
   }
 }
@@ -278,10 +281,18 @@ export async function getVp(
       }
     })
   };
-  const res = await fetch(options.url, init);
-  const json = await res.json();
-  if (json.error) return Promise.reject(json.error);
-  if (json.result) return json.result;
+
+  try {
+    const res = await fetch(options.url, init);
+    const json = await res.json();
+    if (json.error) return Promise.reject(json.error);
+    if (json.result) return json.result;
+  } catch (e) {
+    if (e.errno) {
+      return Promise.reject({ code: e.errno, message: e.toString(), data: '' });
+    }
+    return Promise.reject(e);
+  }
 }
 
 export async function validate(
@@ -311,10 +322,18 @@ export async function validate(
       }
     })
   };
-  const res = await fetch(options.url, init);
-  const json = await res.json();
-  if (json.error) return Promise.reject(json.error);
-  return json.result;
+
+  try {
+    const res = await fetch(options.url, init);
+    const json = await res.json();
+    if (json.error) return Promise.reject(json.error);
+    return json.result;
+  } catch (e) {
+    if (e.errno) {
+      return Promise.reject({ code: e.errno, message: e.toString(), data: '' });
+    }
+    return Promise.reject(e);
+  }
 }
 
 export function validateSchema(schema, data) {
@@ -417,8 +436,7 @@ export async function getDelegatesBySpace(
   snapshot = 'latest',
   options: any = {}
 ) {
-  const subgraphUrl =
-    options.subgraphUrl || SNAPSHOT_SUBGRAPH_URL[network];
+  const subgraphUrl = options.subgraphUrl || SNAPSHOT_SUBGRAPH_URL[network];
   if (!subgraphUrl) {
     return Promise.reject(
       `Delegation subgraph not available for network ${network}`

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -238,6 +238,11 @@ export async function getScores(
       body: JSON.stringify({ params })
     });
     const obj = await res.json();
+
+    if (obj.error) {
+      return Promise.reject(obj.error);
+    }
+
     return options.returnValue === 'all'
       ? obj.result
       : obj.result[options.returnValue || 'scores'];

--- a/test/e2e/utils/getScores.spec.ts
+++ b/test/e2e/utils/getScores.spec.ts
@@ -9,7 +9,7 @@ describe('test getScores', () => {
     ).to.rejects.toHaveProperty('code');
   });
 
-  test.only('getScores should return a promise rejection with JSON-RPC format on network error', async () => {
+  test('getScores should return a promise rejection with JSON-RPC format on network error', async () => {
     expect.assertions(1);
     await expect(
       getScores(

--- a/test/e2e/utils/getScores.spec.ts
+++ b/test/e2e/utils/getScores.spec.ts
@@ -2,10 +2,29 @@ import { test, expect, describe } from 'vitest';
 import { getScores } from '../../../src/utils';
 
 describe('test getScores', () => {
-  test('getScores should returns a promise rejection on error from score-api', async () => {
+  test('getScores should return a promise rejection on error from score-api', async () => {
     expect.assertions(1);
     await expect(
       getScores('test.eth', [], '1', ['0x0'])
     ).to.rejects.toHaveProperty('code');
+  });
+
+  test.only('getScores should return a promise rejection with JSON-RPC format on network error', async () => {
+    expect.assertions(1);
+    await expect(
+      getScores(
+        'test.eth',
+        [],
+        '1',
+        [''],
+        'latest',
+        'https://score-null.snapshot.org'
+      )
+    ).to.rejects.toEqual({
+      code: 'ENOTFOUND',
+      message:
+        'FetchError: request to https://score-null.snapshot.org/api/scores failed, reason: getaddrinfo ENOTFOUND score-null.snapshot.org',
+      data: ''
+    });
   });
 });

--- a/test/e2e/utils/getScores.spec.ts
+++ b/test/e2e/utils/getScores.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect, describe } from 'vitest';
+import { getScores } from '../../../src/utils';
+
+describe('test getScores', () => {
+  test('getScores should returns a promise rejection on error from score-api', async () => {
+    expect.assertions(1);
+    await expect(
+      getScores('test.eth', [], '1', ['0x0'])
+    ).to.rejects.toHaveProperty('code');
+  });
+});


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

When polling the score-api, any network errors will throw a `FetchError`, which is not handled by the SDK, making the caller rescue this error, in addition to handling JSON-RPC error.

The caller will have to handle 3 situations:
- success: a json rpc object, from Promise.resolve
- error on score-api: a json-rpc error object, from Promise.reject
- network error: a thrown Error

## 💊 Fixes / Solution

`getScores` should return only one response format on error, a json-rpc error.

After fix, the caller will have to handle 2 situations:
- success: a json rpc object, with Promise.resolve
- error: a json-rpc error object, from Promise.reject

Which simplify the error handling on the caller side, in addition of getting the error message.

## 🚧 Changes

- for all score-api requests, add a try/catch and return a json-rpc error object on nerwork failure.

## 🛠️ Tests

- Call the `getScores()` function, with an invalid `scoreApiUrl` params.
- It should return a JSON-RPC error, instead of throwing an error