### PR TITLE
Migrate ofetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "@ethersproject/wallet": "^5.6.2",
     "ajv": "^8.11.0",
     "ajv-formats": "^2.1.1",
-    "cross-fetch": "^3.1.6",
     "json-to-graphql-query": "^2.2.4",
-    "lodash.set": "^4.3.2"
+    "lodash.set": "^4.3.2",
+    "ofetch": "^1.3.3"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^18.1.0",

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -87,6 +87,7 @@ export default class Client {
         Accept: 'application/json',
         'Content-Type': 'application/json'
       },
+      timeout: 20e3,
       body: JSON.stringify(envelop)
     };
     return new Promise((resolve, reject) => {

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -1,4 +1,4 @@
-import fetch from 'cross-fetch';
+import { ofetch as fetch } from 'ofetch';
 import { Web3Provider } from '@ethersproject/providers';
 import { Wallet } from '@ethersproject/wallet';
 import { getAddress } from '@ethersproject/address';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -143,6 +143,7 @@ export async function subgraphRequest(url: string, query, options: any = {}) {
       'Content-Type': 'application/json',
       ...options?.headers
     },
+    timeout: 20e3,
     body: JSON.stringify({ query: jsonToGraphQLQuery({ query }) })
   });
   let responseData: any = await res.text();
@@ -184,7 +185,7 @@ export function getUrl(uri, gateway = gateways[0]) {
 
 export async function getJSON(uri, options: any = {}) {
   const url = getUrl(uri, options.gateways);
-  return fetch(url).then((res) => res.json());
+  return fetch(url, { timeout: 30e3 }).then((res) => res.json());
 }
 
 export async function ipfsGet(
@@ -193,7 +194,7 @@ export async function ipfsGet(
   protocolType = 'ipfs'
 ) {
   const url = `https://${gateway}/${protocolType}/${ipfsHash}`;
-  return fetch(url).then((res) => res.json());
+  return fetch(url, { timeout: 20e3 }).then((res) => res.json());
 }
 
 export async function sendTransaction(
@@ -235,6 +236,7 @@ export async function getScores(
     const res = await fetch(scoreApiUrl, {
       method: 'POST',
       headers: scoreApiHeaders,
+      timeout: 60e3,
       body: JSON.stringify({ params })
     });
     const obj = await res.json();
@@ -268,6 +270,7 @@ export async function getVp(
   const init = {
     method: 'POST',
     headers: scoreApiHeaders,
+    timeout: 60e3,
     body: JSON.stringify({
       jsonrpc: '2.0',
       method: 'get_vp',
@@ -309,6 +312,7 @@ export async function validate(
   const init = {
     method: 'POST',
     headers: scoreApiHeaders,
+    timeout: 30e3,
     body: JSON.stringify({
       jsonrpc: '2.0',
       method: 'validate',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import fetch from 'cross-fetch';
+import { ofetch as fetch } from 'ofetch';
 import { Interface } from '@ethersproject/abi';
 import { Contract } from '@ethersproject/contracts';
 import { isAddress } from '@ethersproject/address';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1789,13 +1789,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-fetch@^3.1.6:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.6.tgz#bae05aa31a4da760969756318feeee6e70f15d6c"
-  integrity sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==
-  dependencies:
-    node-fetch "^2.6.11"
-
 cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -1898,6 +1891,11 @@ des.js@^1.0.0:
   dependencies:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
+
+destr@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/destr/-/destr-2.0.1.tgz#2fc7bddc256fed1183e03f8d148391dde4023cb2"
+  integrity sha512-M1Ob1zPSIvlARiJUkKqvAZ3VAqQY6Jcuth/pBKQ2b1dX/Qx0OnJ8Vux6J2H5PTMQeRzWrrbTu70VxBfv/OPDJA==
 
 diff-sequences@^29.4.3:
   version "29.4.3"
@@ -3439,12 +3437,10 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-fetch@^2.6.11:
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
-  integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==
-  dependencies:
-    whatwg-url "^5.0.0"
+node-fetch-native@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/node-fetch-native/-/node-fetch-native-1.4.0.tgz#fbe8ac033cb6aa44bd106b5e4fd2b6277ba70fa1"
+  integrity sha512-F5kfEj95kX8tkDhUCYdV8dg3/8Olx/94zB8+ZNthFs6Bz31UpUi8Xh40TN3thLwXgrwXry1pEg9lJ++tLWTcqA==
 
 node-gyp@^7.1.0:
   version "7.1.2"
@@ -3640,6 +3636,15 @@ octal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/octal/-/octal-1.0.0.tgz#63e7162a68efbeb9e213588d58e989d1e5c4530b"
   integrity sha1-Y+cWKmjvvrniE1iNWOmJ0eXEUws=
+
+ofetch@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/ofetch/-/ofetch-1.3.3.tgz#588cb806a28e5c66c2c47dd8994f9059a036d8c0"
+  integrity sha512-s1ZCMmQWXy4b5K/TW9i/DtiN8Ku+xCiHcjQ6/J/nDdssirrQNOoB165Zu8EqLMA2lln1JUth9a0aW9Ap2ctrUg==
+  dependencies:
+    destr "^2.0.1"
+    node-fetch-native "^1.4.0"
+    ufo "^1.3.0"
 
 once@^1.3.0:
   version "1.4.0"
@@ -4779,11 +4784,6 @@ tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
-
 tslib@1.11.1, tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
@@ -4854,6 +4854,11 @@ ufo@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.1.2.tgz#d0d9e0fa09dece0c31ffd57bd363f030a35cfe76"
   integrity sha512-TrY6DsjTQQgyS3E3dBaOXf0TpPD8u9FVrVYmKVegJuFw51n/YB9XPt+U6ydzFG5ZIN7+DIjPbNmXoBj9esYhgQ==
+
+ufo@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.3.0.tgz#c92f8ac209daff607c57bbd75029e190930a0019"
+  integrity sha512-bRn3CsoojyNStCZe0BG0Mt4Nr/4KF+rhFlnNXybgqt5pXHNFRlqinSoQaTrGyzE4X8aHplSb+TorH+COin9Yxw==
 
 unique-filename@^1.1.1:
   version "1.1.1"
@@ -4986,19 +4991,6 @@ vlq@^0.2.2:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
   integrity sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==
-
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
-
-whatwg-url@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
-  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
 
 which@^1.2.9:
   version "1.3.1"


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

Current `fetch` request does not support timeout, not keep alive connections.

## 💊 Fixes / SolutionM

Migrate the fetch library from `cross-fetch` to `ofetch`

## 🚧 Changes

- Add support for keep alive connections
- Add timeout to all fetch requests

## ‼️ Breaking changes

- `ofetch` is handling error response differently, and is rejecting a Promise on all non-200 errors.

## 🛠️ Tests

