### PR TITLE
chore: run CI tests on more node versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['14', 16', '18', '20']
+        node-version: ['14', '16', '18', '20']
 
     steps:
       - uses: actions/checkout@v2.3.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
         node-version: ['14', '16', '18', '20']
 
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: yarn install, build and run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['14', '16', '18', '20']
+        node-version: ['14', '20']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: ['14', 16', '18', '20']
 
     steps:
       - uses: actions/checkout@v2.3.4


### PR DESCRIPTION
Run the github action tests on more node versions.

It's currently only ran on node 14, which is dead for many years.

Adding 16 (which is EOL but is still used by many of our services), 18 (current) and 20.

This will avoid scenario like https://github.com/snapshot-labs/snapshot.js/pull/904 which fails on node 18
