### PR TITLE
fix: Update multicall for mumbai network

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/networks.json
+++ b/src/networks.json
@@ -2220,7 +2220,7 @@
     "chainId": 80001,
     "network": "testnet",
     "testnet": true,
-    "multicall": "0x08411ADd0b5AA8ee47563b146743C13b3556c9Cc",
+    "multicall": "0xcA11bde05977b3631167028862bE2a173976CA11",
     "rpc": [
       "https://speedy-nodes-nyc.moralis.io/9e03baabdc27be2a35bdec4a/polygon/mumbai/archive",
       "https://rpc-mumbai.matic.today"


### PR DESCRIPTION
We are using a older version of multicall