### PR TITLE
fix: check for invalid arguments in `validate`

### DIFF
--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -67,7 +67,7 @@ describe('utils', () => {
         [
           'snapshot is smaller than start block',
           { snapshot: 1234 },
-          /snapshot \([0-9]+\) must be greater than network start block/i
+          /snapshot \([0-9]+\) must be 'latest' or greater than network start block/i
         ]
       ];
 

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -1,0 +1,164 @@
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import * as crossFetch from 'cross-fetch';
+import { validate } from './utils';
+
+vi.mock('cross-fetch', async () => {
+  const actual = await vi.importActual('cross-fetch');
+
+  return {
+    ...actual,
+    default: vi.fn()
+  };
+});
+const fetch = vi.mocked(crossFetch.default);
+
+describe('utils', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('validate', () => {
+    const payload = {
+      validation: 'basic',
+      author: '0xeF8305E140ac520225DAf050e2f71d5fBcC543e7',
+      space: 'fabien.eth',
+      network: '1',
+      snapshot: 7929876,
+      params: {
+        minScore: 0.9,
+        strategies: [
+          {
+            name: 'eth-balance',
+            params: {}
+          }
+        ]
+      }
+    };
+
+    function _validate({
+      validation,
+      author,
+      space,
+      network,
+      snapshot,
+      params,
+      options
+    }) {
+      return validate(
+        validation ?? payload.validation,
+        author ?? payload.author,
+        space ?? payload.space,
+        network ?? payload.network,
+        snapshot ?? payload.snapshot,
+        params ?? payload.params,
+        options ?? {}
+      );
+    }
+
+    describe('when passing invalid args', () => {
+      const cases = [
+        [
+          'author is an invalid address',
+          { author: 'test-address' },
+          /invalid author/i
+        ],
+        ['network is not valid', { network: 'mainnet' }, /invalid network/i],
+        ['network is empty', { network: '' }, /invalid network/i],
+        [
+          'snapshot is smaller than start block',
+          { snapshot: 1234 },
+          /snapshot \([0-9]+\) must be greater than network start block/i
+        ]
+      ];
+
+      test.each(cases)('throw an error when %s', async (title, args, err) => {
+        await expect(() => _validate(args)).rejects.toThrowError(err);
+      });
+    });
+
+    describe('when passing valid args', () => {
+      test('send a JSON-RPC payload to score-api', async () => {
+        fetch.mockReturnValue({
+          json: () => new Promise((resolve) => resolve({ result: 'OK' }))
+        });
+
+        expect(_validate({})).resolves;
+        expect(fetch).toHaveBeenCalledWith(
+          'https://score.snapshot.org',
+          expect.objectContaining({
+            body: JSON.stringify({
+              jsonrpc: '2.0',
+              method: 'validate',
+              params: payload
+            })
+          })
+        );
+      });
+
+      test('send a POST request with JSON content-type', async () => {
+        fetch.mockReturnValue({
+          json: () => new Promise((resolve) => resolve({ result: 'OK' }))
+        });
+
+        expect(_validate({})).resolves;
+        expect(fetch).toHaveBeenCalledWith(
+          'https://score.snapshot.org',
+          expect.objectContaining({
+            method: 'POST',
+            headers: {
+              Accept: 'application/json',
+              'Content-Type': 'application/json'
+            }
+          })
+        );
+      });
+
+      test('can customize the score-api url', () => {
+        fetch.mockReturnValue({
+          json: () => new Promise((resolve) => resolve({ result: 'OK' }))
+        });
+
+        expect(
+          _validate({ options: { url: 'https://snapshot.org/?apiKey=xxx' } })
+        ).resolves;
+        expect(fetch).toHaveBeenCalledWith(
+          'https://snapshot.org/?apiKey=xxx',
+          expect.anything()
+        );
+      });
+
+      test('returns the JSON-RPC result property', () => {
+        const result = { result: 'OK' };
+        fetch.mockReturnValue({
+          json: () => new Promise((resolve) => resolve(result))
+        });
+
+        expect(_validate({})).resolves.toEqual('OK');
+      });
+    });
+
+    describe('when score-api is sending a JSON-RPC error', () => {
+      test('rejects with the JSON-RPC error object', () => {
+        const result = { error: { message: 'Oh no' } };
+        fetch.mockReturnValue({
+          json: () => new Promise((resolve) => resolve(result))
+        });
+
+        expect(_validate({})).rejects.toEqual(result.error);
+      });
+    });
+
+    describe('when the fetch request is failing with not network error', () => {
+      test('rejects with the error', () => {
+        const result = new Error('Oh no');
+        fetch.mockReturnValue({
+          json: () => {
+            throw result;
+          }
+        });
+
+        expect(_validate({})).rejects.toEqual(result);
+      });
+    });
+  });
+});

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -72,7 +72,7 @@ describe('utils', () => {
       ];
 
       test.each(cases)('throw an error when %s', async (title, args, err) => {
-        await expect(() => _validate(args)).rejects.toThrowError(err);
+        await expect(_validate(args)).rejects.toMatch(err);
       });
     });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -554,8 +554,8 @@ function isValidAddress(address: string) {
 
 function isValidSnapshot(snapshot: number | string, network: string) {
   return (
-    (typeof snapshot === 'number' && snapshot >= networks[network].start) ||
-    snapshot === 'latest'
+    snapshot === 'latest' ||
+    (typeof snapshot === 'number' && snapshot >= networks[network].start)
   );
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -306,6 +306,19 @@ export async function validate(
   params: any,
   options: any
 ) {
+  if (!isAddress(author)) {
+    throw new Error(`Invalid author: ${author}`);
+  }
+
+  if (!networks[network]) {
+    throw new Error(`Invalid network: ${network}`);
+  }
+  if (typeof snapshot === 'number' && snapshot < networks[network].start) {
+    throw new Error(
+      `Snapshot (${snapshot}) must be greater than network start block (${networks[network].start})`
+    );
+  }
+
   if (!options) options = {};
   if (!options.url) options.url = 'https://score.snapshot.org';
   const init = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -343,7 +343,7 @@ export async function validate(
   }
   if (!isValidSnapshot(snapshot, network)) {
     return Promise.reject(
-      `Snapshot (${snapshot}) must be greater than network start block (${networks[network].start})`
+      `Snapshot (${snapshot}) must be 'latest' or greater than network start block (${networks[network].start})`
     );
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -307,14 +307,14 @@ export async function validate(
   options: any
 ) {
   if (!isAddress(author)) {
-    throw new Error(`Invalid author: ${author}`);
+    return Promise.reject(`Invalid author: ${author}`);
   }
 
   if (!networks[network]) {
-    throw new Error(`Invalid network: ${network}`);
+    return Promise.reject(`Invalid network: ${network}`);
   }
   if (typeof snapshot === 'number' && snapshot < networks[network].start) {
-    throw new Error(
+    return Promise.reject(
       `Snapshot (${snapshot}) must be greater than network start block (${networks[network].start})`
     );
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,6 +31,7 @@ export const SNAPSHOT_SUBGRAPH_URL = delegationSubgraphs;
 const ENS_RESOLVER_ABI = [
   'function text(bytes32 node, string calldata key) external view returns (string memory)'
 ];
+const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 const scoreApiHeaders = {
   Accept: 'application/json',
@@ -306,14 +307,14 @@ export async function validate(
   params: any,
   options: any
 ) {
-  if (!isAddress(author)) {
+  if (!isValidAddress(author)) {
     return Promise.reject(`Invalid author: ${author}`);
   }
 
-  if (!networks[network]) {
+  if (!isValidNetwork(network)) {
     return Promise.reject(`Invalid network: ${network}`);
   }
-  if (typeof snapshot === 'number' && snapshot < networks[network].start) {
+  if (!isValidSnapshot(snapshot, network)) {
     return Promise.reject(
       `Snapshot (${snapshot}) must be greater than network start block (${networks[network].start})`
     );
@@ -508,6 +509,21 @@ export function getNumberWithOrdinal(n) {
   const s = ['th', 'st', 'nd', 'rd'],
     v = n % 100;
   return n + (s[(v - 20) % 10] || s[v] || s[0]);
+}
+
+function isValidNetwork(network: string) {
+  return !!networks[network];
+}
+
+function isValidAddress(address: string) {
+  return isAddress(address) && address !== EMPTY_ADDRESS;
+}
+
+function isValidSnapshot(snapshot: number | string, network: string) {
+  return (
+    (typeof snapshot === 'number' && snapshot >= networks[network].start) ||
+    snapshot === 'latest'
+  );
 }
 
 export default {


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

From https://github.com/orgs/snapshot-labs/projects/12/views/7?pane=issue&itemId=43073796

The `validate` passes the arguments as is to score-api without check. There are some basic check possible from the SDK, to filter out invalid requests, and lighten the score-api server load.

This will also avoid log pollution on score-api, making the log more relevant

## 💊 Fixes / Solution

Fix #924

Add some basic argument validation on the SDK side, and return a meaningful error when argument are not valid.

## 🚧 Changes

- Add check that author address is valid
- Add check that network is not empty, and valid (referenced in networks.json)
- Check that the given `snapshot` is in the network range (should be greater than the network's `start` block)
- Check that `network` in strategies are valid
- Fully tests `validate`

## 🛠️ Tests

- Send some request to `validate` functions, with invalid data
- The function should throw an error with an error message