### PR TITLE
Fix chain id for KardiaChain Mainnet and neon devnet

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -1238,8 +1238,8 @@
     },
     "logo": "ipfs://QmYACyZcidcFtMo4Uf9H6ZKUxTP2TQPjGzNjcUjqYa64dt"
   },
-  "1002": {
-    "key": "1002",
+  "24": {
+    "key": "24",
     "name": "KardiaChain Mainnet",
     "shortName": "KAI",
     "chainId": 24,
@@ -2441,7 +2441,7 @@
     "key": "245022926",
     "name": "Neon Devnet",
     "shortName": "devnet",
-    "chainId": 245022934,
+    "chainId": 245022926,
     "network": "testnet",
     "multicall": "0xcA11bde05977b3631167028862bE2a173976CA11",
     "rpc": [],


### PR DESCRIPTION
These have the wrong chainID and key