### PR TITLE
feat: Check if network is mainnet or testnet depending on env

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -79,6 +79,7 @@
         },
         "network": {
           "type": "string",
+          "snapshotNetwork": true,
           "title": "network",
           "minLength": 1,
           "maxLength": 32
@@ -114,7 +115,8 @@
               "network": {
                 "type": "string",
                 "maxLength": 12,
-                "title": "network"
+                "title": "network",
+                "snapshotNetwork": true
               },
               "params": {
                 "type": "object",
@@ -346,6 +348,7 @@
               },
               "network": {
                 "type": "string",
+                "snapshotNetwork": true,
                 "title": "Network",
                 "maxLength": 12
               }

--- a/src/schemas/zodiac.json
+++ b/src/schemas/zodiac.json
@@ -15,7 +15,8 @@
             "properties": {
               "network": {
                 "title": "Network",
-                "type": "string"
+                "type": "string",
+                "snapshotNetwork": true
               },
               "multisend": {
                 "title": "Multisend contract address",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,7 +37,12 @@ const scoreApiHeaders = {
   'Content-Type': 'application/json'
 };
 
-const ajv = new Ajv({ allErrors: true, allowUnionTypes: true, $data: true });
+const ajv = new Ajv({
+  allErrors: true,
+  allowUnionTypes: true,
+  $data: true,
+  passContext: true
+});
 // @ts-ignore
 addFormats(ajv);
 
@@ -65,6 +70,28 @@ ajv.addFormat('ethValue', {
     } catch {
       return false;
     }
+  }
+});
+
+const networksIds = Object.keys(networks);
+const mainnetNetworkIds = Object.keys(networks).filter(
+  (id) => !networks[id].testnet
+);
+const testnetNetworkIds = Object.keys(networks).filter(
+  (id) => networks[id].testnet
+);
+
+ajv.addKeyword({
+  keyword: 'snapshotNetwork',
+  validate: function (schema, data) {
+    // @ts-ignore
+    const snapshotEnv = this.snapshotEnv || 'default';
+    if (snapshotEnv === 'mainnet') return mainnetNetworkIds.includes(data);
+    if (snapshotEnv === 'testnet') return testnetNetworkIds.includes(data);
+    return networksIds.includes(data);
+  },
+  error: {
+    message: 'must be a valid network used by snapshot'
   }
 });
 
@@ -338,9 +365,15 @@ export async function validate(
   }
 }
 
-export function validateSchema(schema, data) {
+export function validateSchema(
+  schema,
+  data,
+  options = {
+    snapshotEnv: 'default'
+  }
+) {
   const ajvValidate = ajv.compile(schema);
-  const valid = ajvValidate(data);
+  const valid = ajvValidate.call(options, data);
   return valid ? valid : ajvValidate.errors;
 }
 

--- a/test/schema.spec.ts
+++ b/test/schema.spec.ts
@@ -18,7 +18,7 @@ describe.each([
   { schemaType: 'alias', schema: schemas.alias, example: alias }
 ])(`Run validate for all schemas`, ({ schemaType, schema, example }) => {
   test(`validating schema ${schemaType} should return true`, () => {
-    const isValid = validateSchema(schema, example);
+    const isValid = validateSchema(schema, example, { snapshotEnv: 'mainnet' });
     expect(isValid).toBe(true);
   });
 });


### PR DESCRIPTION
- Add a new keyword `snapshotKeyword` to check if the network exists in networks.json or not
- If snapshot's env is `mainnet` it will check only mainnet networks
- if snapshot's env is `testnet` it will check only testnet networks


To Do: 
- [ ] On UI and sequencer, need to update `validateSchema` function to pass the env in the third optional param 
```js
validateSchema(schema, data, { snapshotEnv: 'mainnet' })
```