### PR TITLE
Update smartbch rpc with fallbacks

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -1086,7 +1086,7 @@
       "https://rpc.smartbch.org"
     ],
     "explorer": {
-      "url": "https://www.smartscan.cash"
+      "url": "https://smartbch-explorer.web.app"
     },
     "logo": "ipfs://QmWG1p7om4hZ4Yi4uQvDpxg4si7qVYhtppGbcDGrhVFvMd"
   },

--- a/src/networks.json
+++ b/src/networks.json
@@ -1080,10 +1080,7 @@
     "network": "mainnet",
     "multicall": "0x1b38EBAd553f218e2962Cb1C0539Abb5d6A37774",
     "rpc": [
-      "https://global.uat.cash",
-      "https://smartbch.fountainhead.cash/mainnet",
-      "https://smartbch.greyh.at",
-      "https://rpc.smartbch.org"
+      "https://smartbch.greyh.at/"
     ],
     "explorer": {
       "url": "https://smartbch-explorer.web.app"

--- a/src/networks.json
+++ b/src/networks.json
@@ -1080,7 +1080,10 @@
     "network": "mainnet",
     "multicall": "0x1b38EBAd553f218e2962Cb1C0539Abb5d6A37774",
     "rpc": [
-      "https://smartbch.greyh.at/"
+      "https://global.uat.cash",
+      "https://smartbch.fountainhead.cash/mainnet",
+      "https://smartbch.greyh.at",
+      "https://rpc.smartbch.org"
     ],
     "explorer": {
       "url": "https://www.smartscan.cash"


### PR DESCRIPTION
Update smartbch rpc with more fallbacks

Fixes # single dependency on one RPC node which was offline, causing vote weight to not calculate properly

Changes proposed in this pull request:
- Add addditional RPC endpoints for greater fallback

