### PR TITLE
fix: Ranked Choice total voting power

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/voting/rankedChoice.ts
+++ b/src/voting/rankedChoice.ts
@@ -149,7 +149,7 @@ export default class RankedChoiceVoting {
   }
 
   getScoresTotal(): number {
-    return getScoresMethod(this.votes, this.proposal).reduce((a, b) => a + b);
+    return this.votes.reduce((a, b: any) => a + b.balance, 0);
   }
 
   getChoiceString(): string {


### PR DESCRIPTION
Right now, In ranked choice voting

we calculate the total voting power of all votes after all rounds, which is the same as total voting power of all votes anyway

This is causing problems with shutter, If we want to calculate total voting power after all rounds of RCV, we need all choices to be decrypted, so in this change we are just calculating total voting power of all votes like all other voting types