### PR TITLE
fix: return http error code and message when failing to connect to score-api

### DIFF
--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -314,19 +314,6 @@ describe('utils', () => {
         expect(_getScores({})).rejects.toEqual(result.error);
       });
     });
-
-    describe('when the fetch request is failing with not network error', () => {
-      test('rejects with the error', () => {
-        const result = new Error('Oh no');
-        fetch.mockReturnValue({
-          json: () => {
-            throw result;
-          }
-        });
-
-        expect(_getScores({})).rejects.toEqual(result);
-      });
-    });
   });
   describe('getVp', () => {
     const payload = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -134,7 +134,6 @@ ajv.addKeyword({
   errors: true
 });
 
-
 // Custom URL format to allow empty string values
 // https://github.com/snapshot-labs/snapshot.js/pull/541/files
 ajv.addFormat('customUrl', {
@@ -333,16 +332,28 @@ export async function getScores(
       headers: scoreApiHeaders,
       body: JSON.stringify({ params })
     });
-    const obj = await res.json();
+    let json: Record<string, any> = {};
 
-    if (obj.error) {
-      return Promise.reject(obj.error);
+    try {
+      json = await res.json();
+    } catch (e: any) {
+      if (!res.ok) {
+        return Promise.reject({
+          code: res.status,
+          message: res.statusText,
+          data: ''
+        });
+      }
+    }
+
+    if (json.error) {
+      return Promise.reject(json.error);
     }
 
     return options.returnValue === 'all'
-      ? obj.result
-      : obj.result[options.returnValue || 'scores'];
-  } catch (e) {
+      ? json.result
+      : json.result[options.returnValue || 'scores'];
+  } catch (e: any) {
     if (e.errno) {
       return Promise.reject({ code: e.errno, message: e.toString(), data: '' });
     }
@@ -401,10 +412,23 @@ export async function getVp(
 
   try {
     const res = await fetch(options.url, init);
-    const json = await res.json();
+    let json: Record<string, any> = {};
+
+    try {
+      json = await res.json();
+    } catch (e: any) {
+      if (!res.ok) {
+        return Promise.reject({
+          code: res.status,
+          message: res.statusText,
+          data: ''
+        });
+      }
+    }
+
     if (json.error) return Promise.reject(json.error);
     if (json.result) return json.result;
-  } catch (e) {
+  } catch (e: any) {
     if (e.errno) {
       return Promise.reject({ code: e.errno, message: e.toString(), data: '' });
     }
@@ -455,10 +479,23 @@ export async function validate(
 
   try {
     const res = await fetch(options.url, init);
-    const json = await res.json();
+    let json: Record<string, any> = {};
+
+    try {
+      json = await res.json();
+    } catch (e: any) {
+      if (!res.ok) {
+        return Promise.reject({
+          code: res.status,
+          message: res.statusText,
+          data: ''
+        });
+      }
+    }
+
     if (json.error) return Promise.reject(json.error);
     return json.result;
-  } catch (e) {
+  } catch (e: any) {
     if (e.errno) {
       return Promise.reject({ code: e.errno, message: e.toString(), data: '' });
     }

--- a/test/e2e/utils/getScores.spec.ts
+++ b/test/e2e/utils/getScores.spec.ts
@@ -29,4 +29,22 @@ describe('test getScores', () => {
       data: ''
     });
   });
+
+  test('getScores should return a promise rejection with JSON-RPC format on network error', async () => {
+    expect.assertions(1);
+    await expect(
+      getScores(
+        'test.eth',
+        [],
+        '1',
+        ['0x9e8f6CF284Db7a80646D9d322A37b3dAF461F8DD'],
+        'latest',
+        'https://snapshot.org'
+      )
+    ).to.rejects.toEqual({
+      code: 405,
+      message: 'Method Not Allowed',
+      data: ''
+    });
+  });
 });


### PR DESCRIPTION
## 🧿 Current issues / What's wrong ?

On http error, (504, 524, etc...) where the `getScore`, `getVp` and `validate` fetch requests are unable to connect to api, the request is failing with a plain `invalid json response body at https://...` error

This does not have any indications on the caller side why the error is failing, and making it difficult to handle (should retry?)

## 💊 Fixes / Solution

API already return a well formatted JSON-RPC error, only cases where this jaon parsing error happens is for HTML response returned by cloudflare

We should return a meaningful JSON-RPC error when the HTTP request to the API is failing.

Example, on a timeout http error from cloudflare, the request will now rejects with

```json
{
      code: 405,
      message: 'Method Not Allowed',
      data: ''
    }
```

instead of rejects with a `invalid json response body ...` error


## 🚧 Changes

- Try/Catch the `res.json()` call, to return a JSON-RPC formatted error, with the HTTP status and message

## 🛠️ Tests

