### PR TITLE
feat: Add quorumType to space settings

### DIFF
--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -304,6 +304,10 @@
               "type": "number",
               "minimum": 0
             },
+            "quorumType": {
+              "type": "string",
+              "enum": ["optimistic"]
+            },
             "blind": {
               "type": "boolean"
             },

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -45,8 +45,8 @@ const VERSION = '0.1.4';
 
 export const domain = {
   name: NAME,
-  version: VERSION,
-  chainId: 1
+  version: VERSION
+  // chainId: 1
 };
 
 export default class Client {

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -45,8 +45,8 @@ const VERSION = '0.1.4';
 
 export const domain = {
   name: NAME,
-  version: VERSION
-  // chainId: 1
+  version: VERSION,
+  chainId: 1
 };
 
 export default class Client {

--- a/test/examples/space.json
+++ b/test/examples/space.json
@@ -31,6 +31,7 @@
   },
   "voting":{
     "delay": 2592000,
-    "period": 15552000
+    "period": 15552000,
+    "quorum": 100
   }
 }


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/snapshot/issues/4600

This will add ability to send a new space settings to store optimistic quorum (default to undefined)

## How to test:
- Run `yarn test` 
- Change values in `examples/space.json`
- Try passing different values to `quorumType` 
- If `quorumType` exist, It should accept only `optimistic` and reject all 