### PR TITLE
fix: Add disabled and bribeEnabled as required fields inside boost object

### DIFF
--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -391,6 +391,7 @@
               "type": "boolean"
             }
           },
+          "required": ["disabled", "bribeEnabled"],
           "additionalProperties": false
         }
       },


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/snapshot-hub/issues/822

Right now it accepts even if user pass invalid objects like

```json
"boost":{}
```

```json
"boost": {
    "disabled": true
 }
```

```json
"boost":  {
    "bribeDisabled": false
}
```

With this fix it will accept only if both fields are present, if we have `boost` object in settings,
so these will be valid
```json
{
    "name": "Test",
    "treasuries": [],
    ...
    "boost": {
        "disabled": false,
        "bribeEnabled": false
    }
}
```

```json
{
    "name": "Test",
    "treasuries": [],
    ....
    // without boost object
}
```