### PR TITLE
fix: UI doesn't show any error if sequencer is down or unavailable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -97,7 +97,7 @@ export default class Client {
           if (res.ok) return resolve(res.json());
           throw res;
         })
-        .catch((e) => e.json().then((json) => reject(json)));
+        .catch((e) => reject(e));
     });
   }
 

--- a/test/test.html
+++ b/test/test.html
@@ -1,0 +1,39 @@
+<!-- serve -p 9000 -->
+<!-- Go to http://localhost:9000/test/test.html -->
+<script src="../dist/snapshot.min.js"></script>
+<script src="https://cdn.ethers.io/lib/ethers-5.6.umd.min.js" type="text/javascript">
+</script>
+
+
+
+<button id="connectButton">Connect</button>
+<button id="voteButton">Vote</button>
+
+<script>
+  const hub = 'http://localhost:3001'; // or https://testnet.hub.snapshot.org for testnet
+  const client = new snapshot.Client712(hub);
+
+  // Connect to Ethereum wallet
+  document.getElementById("connectButton").addEventListener("click", async () => {
+    await window.ethereum.request({ method: 'eth_requestAccounts' });
+    console.log('Connected to wallet', await window.ethereum.request({ method: 'eth_accounts' }));
+  });
+
+  // Vote using snapshot.js
+  document.getElementById("voteButton").addEventListener("click", async () => {
+    const web3 = new ethers.providers.Web3Provider(window.ethereum);
+    const [account] = await web3.listAccounts();
+    try {
+      const receipt = await client.vote(web3, account, {
+        space: 'yam.eth',
+        proposal: '0x21ea31e896ec5b5a49a3653e51e787ee834aaf953263144ab936ed756f36609f',
+        type: 'single-choice',
+        choice: 1,
+        reason: 'Choice 1 make lot of sense',
+        app: 'my-app'
+      });
+    } catch (error) {
+      console.log('catched an error', error);
+    }
+  });
+</script>

--- a/test/test.html
+++ b/test/test.html
@@ -1,3 +1,4 @@
+<!-- This is a simple example of how to use snapshot.js to vote using a web3 provider -->
 <!-- serve -p 9000 -->
 <!-- Go to http://localhost:9000/test/test.html -->
 <script src="../dist/snapshot.min.js"></script>


### PR DESCRIPTION
- Right now if there is a network issue (internet issue or if sequencer/relayer is down, we couldn't show a error because of this
- This creates lot of confusions with safe voting, especially when it doesn't show any message while voting 
- It return following error 
- ![image](https://github.com/snapshot-labs/snapshot.js/assets/15967809/299440a7-d524-4be3-992e-0f0f74e71632)
- UI is stuck like this without any error
![image](https://github.com/snapshot-labs/snapshot.js/assets/15967809/de066ff8-ad05-48f5-81e9-86100c10e0c1)


## How to test
Use the newly added test.html to test signing when sequencer is not available 
- Run `yarn build` (without the fix)
- Run `serve -p 9000` 
- Go to  http://localhost:9000/test/test.html
- Try voting , and should return a Uncaught error
- Now with new fix run `yarn build`
- Run `serve -p 9000` 
- Go to  http://localhost:9000/test/test.html
- Try voting, and you see a caught error of `Network request failed`