### PR TITLE
chore: remove deprecated vote types

### DIFF
--- a/src/sign/types.ts
+++ b/src/sign/types.ts
@@ -188,45 +188,6 @@ export const cancelProposal2Types = {
   ]
 };
 
-export const voteTypes = {
-  Vote: [
-    { name: 'from', type: 'address' },
-    { name: 'space', type: 'string' },
-    { name: 'timestamp', type: 'uint64' },
-    { name: 'proposal', type: 'string' },
-    { name: 'choice', type: 'uint32' },
-    { name: 'reason', type: 'string' },
-    { name: 'app', type: 'string' },
-    { name: 'metadata', type: 'string' }
-  ]
-};
-
-export const voteArrayTypes = {
-  Vote: [
-    { name: 'from', type: 'address' },
-    { name: 'space', type: 'string' },
-    { name: 'timestamp', type: 'uint64' },
-    { name: 'proposal', type: 'string' },
-    { name: 'choice', type: 'uint32[]' },
-    { name: 'reason', type: 'string' },
-    { name: 'app', type: 'string' },
-    { name: 'metadata', type: 'string' }
-  ]
-};
-
-export const voteStringTypes = {
-  Vote: [
-    { name: 'from', type: 'address' },
-    { name: 'space', type: 'string' },
-    { name: 'timestamp', type: 'uint64' },
-    { name: 'proposal', type: 'string' },
-    { name: 'choice', type: 'string' },
-    { name: 'reason', type: 'string' },
-    { name: 'app', type: 'string' },
-    { name: 'metadata', type: 'string' }
-  ]
-};
-
 export const vote2Types = {
   Vote: [
     { name: 'from', type: 'address' },


### PR DESCRIPTION
TODO:

- Remove hash types from https://github.com/snapshot-labs/snapshot.js/blob/master/src/sign/hashedTypes.json