### PR TITLE
fix: Reject with json if request fails with json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.11.14",
+  "version": "0.11.15",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -108,15 +108,10 @@ export default class Client {
         .then((res) => {
           if (res.ok) return resolve(res.json());
           if (res.headers.get('content-type')?.includes('application/json'))
-            return res
-              .json()
-              .then((e) => reject(e))
-              .catch((e) => {
-                reject(e);
-              });
+            return res.json().then(reject).catch(reject);
           throw res;
         })
-        .catch((e) => reject(e));
+        .catch(reject);
     });
   }
 

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -108,7 +108,12 @@ export default class Client {
         .then((res) => {
           if (res.ok) return resolve(res.json());
           if (res.headers.get('content-type')?.includes('application/json'))
-            return res.json().then((e) => reject(e));
+            return res
+              .json()
+              .then((e) => reject(e))
+              .catch((e) => {
+                reject(e);
+              });
           throw res;
         })
         .catch((e) => reject(e));

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -107,6 +107,8 @@ export default class Client {
       fetch(address, init)
         .then((res) => {
           if (res.ok) return resolve(res.json());
+          if (res.headers.get('content-type')?.includes('application/json'))
+            return res.json().then((e) => reject(e));
           throw res;
         })
         .catch((e) => reject(e));


### PR DESCRIPTION
Right now sequencer sends a response object with an error, we have removed it here #981 as it is avoiding some errors like network errors