### PR TITLE
fix: Update subgrapher delegation URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.11.18",
+  "version": "0.11.19",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/delegationSubgraphs.json
+++ b/src/delegationSubgraphs.json
@@ -1,11 +1,11 @@
 {
-  "1": "https://subgrapher.snapshot.org/gateway-arbitrum.network.thegraph.com/api/0f15b42bdeff7a063a4e1757d7e2f99e/subgraphs/id/4YgtogVaqoM8CErHWDK8mKQ825BcVdKB8vBYmb4avAQo",
-  "5": "https://subgrapher.snapshot.org/api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-goerli",
-  "10": "https://subgrapher.snapshot.org/api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-optimism",
-  "56": "https://subgrapher.snapshot.org/api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-binance-smart-chain",
-  "100": "https://subgrapher.snapshot.org/api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-gnosis-chain",
-  "137": "https://subgrapher.snapshot.org/api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-polygon",
-  "250": "https://subgrapher.snapshot.org/api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-fantom",
-  "42161": "https://subgrapher.snapshot.org/api.thegraph.com/subgraphs/name/snapshot-labs/snapshot-arbitrum",
-  "11155111": "https://subgrapher.snapshot.org/gateway-arbitrum.network.thegraph.com/api/0f15b42bdeff7a063a4e1757d7e2f99e/subgraphs/id/2SZVRR6G8txMFtf39aw2aP7BTAawRVwgqHeQXMhr7BRJ"
+  "1": "https://subgrapher.snapshot.org/delegation/1",
+  "5": "https://subgrapher.snapshot.org/delegation/5",
+  "10": "https://subgrapher.snapshot.org/delegation/10",
+  "56": "https://subgrapher.snapshot.org/delegation/56",
+  "100": "https://subgrapher.snapshot.org/delegation/100",
+  "137": "https://subgrapher.snapshot.org/delegation/137",
+  "250": "https://subgrapher.snapshot.org/delegation/250",
+  "42161": "https://subgrapher.snapshot.org/delegation/42161",
+  "11155111": "https://subgrapher.snapshot.org/delegation/11155111"
 }


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/subgrapher/pull/35