### PR TITLE
Add Split-Delegation to delegate portal options

### DIFF
--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -248,7 +248,8 @@
               "title": "Delegation type",
               "description": "Specify the type of delegation that you are using",
               "anyOf": [
-                { "const": "compound-governor", "title": "Compound governor" }
+                { "const": "compound-governor", "title": "Compound governor" },
+                { "const": "split-delegation", "title": "Split Delegation" }
               ]
             },
             "delegationContract": {


### PR DESCRIPTION
This allows for space settings to use `split-delegation` in their settings, which is the first step to integrating it into the Snapshot settings UI.
