### PR TITLE
feat: add support for starknet address

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.11.28",
+  "version": "0.11.29",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,7 +89,7 @@ addErrors(ajv);
 ajv.addFormat('address', {
   validate: (value: string) => {
     try {
-      return isAddress(value);
+      return /^0x[0-9a-fA-F]{62,64}$/.test(value) || isAddress(value);
     } catch (err) {
       return false;
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -99,7 +99,7 @@ ajv.addFormat('address', {
 ajv.addFormat('evmOrStarknetAddress', {
   validate: (value: string) => {
     try {
-      return /^0x[0-9a-fA-F]{62,64}$/.test(value);
+      return isAddress(value) || /^0x[0-9a-fA-F]{62,64}$/.test(value);
     } catch (err) {
       return false;
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,7 +89,17 @@ addErrors(ajv);
 ajv.addFormat('address', {
   validate: (value: string) => {
     try {
-      return /^0x[0-9a-fA-F]{62,64}$/.test(value) || isAddress(value);
+      return isAddress(value);
+    } catch (err) {
+      return false;
+    }
+  }
+});
+
+ajv.addFormat('evmOrStarknetAddress', {
+  validate: (value: string) => {
+    try {
+      return /^0x[0-9a-fA-F]{62,64}$/.test(value);
     } catch (err) {
       return false;
     }

--- a/test/e2e/utils/delegation.spec.ts
+++ b/test/e2e/utils/delegation.spec.ts
@@ -32,7 +32,7 @@ describe('test delegation', () => {
 
     test('should return an empty array when no results', async () => {
       expect.assertions(1);
-      const results: any = await getDelegatesBySpace(NETWORK, SPACE, 22531439);
+      const results: any = await getDelegatesBySpace(NETWORK, SPACE, 22531440);
 
       expect(results.length).toEqual(0);
     });


### PR DESCRIPTION
Add a new validatin rule for validating evm/starknet address

Inspired by how Argent X is validating starknet address https://github.com/argentlabs/argent-starknet-recover/blob/main/schema.ts#L43