### PR TITLE
feat: add more fields to user profile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.11.27",
+  "version": "0.11.28",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/schemas/profile.json
+++ b/src/schemas/profile.json
@@ -21,6 +21,18 @@
           "title": "avatar",
           "format": "customUrl",
           "maxLength": 256
+        },
+        "twitter": {
+          "type": "string",
+          "title": "twitter",
+          "pattern": "^[A-Za-z0-9_]*$",
+          "maxLength": 15
+        },
+        "github": {
+          "type": "string",
+          "title": "github",
+          "pattern": "^[A-Za-z0-9_-]*$",
+          "maxLength": 39
         }
       },
       "required": [],

--- a/src/schemas/profile.json
+++ b/src/schemas/profile.json
@@ -22,6 +22,12 @@
           "format": "customUrl",
           "maxLength": 256
         },
+        "cover": {
+          "type": "string",
+          "title": "avatar",
+          "format": "customUrl",
+          "maxLength": 256
+        },
         "twitter": {
           "type": "string",
           "title": "twitter",


### PR DESCRIPTION
Used in https://github.com/snapshot-labs/sx-monorepo/pull/394

Add `cover`, `twitter` and `github` to user profile