### PR TITLE
fix: make about field optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.11.34",
+  "version": "0.11.35",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/schemas/statement.json
+++ b/src/schemas/statement.json
@@ -37,7 +37,7 @@
           "title": "status"
         }
       },
-      "required": ["about"],
+      "required": [],
       "additionalProperties": false
     }
   }


### PR DESCRIPTION
Make the `about` property in Statement optional. 

This field is not used at all on SX