### PR TITLE
Fix make about field optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.11.35",
+  "version": "0.11.36",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/schemas/statement.json
+++ b/src/schemas/statement.json
@@ -37,7 +37,7 @@
           "title": "status"
         }
       },
-      "required": ["about"],
+      "required": [],
       "additionalProperties": false
     }
   }

--- a/src/schemas/statement.json
+++ b/src/schemas/statement.json
@@ -10,7 +10,6 @@
           "type": "string",
           "format": "long",
           "title": "About",
-          "minLength": 1,
           "maxLength": 140
         },
         "statement": {
@@ -23,8 +22,7 @@
           "type": "string",
           "title": "discourse",
           "pattern": "^[A-Za-z0-9-_.]*$",
-          "maxLength": 30,
-          "minLength": 3
+          "maxLength": 30
         },
         "network": {
           "type": "string",


### PR DESCRIPTION
This PR removes `minLength` on `about` and `discourse` properties, thus allowing empty string as valid value.