### PR TITLE
fix: uppercase statement status options

### DIFF
--- a/src/schemas/statement.json
+++ b/src/schemas/statement.json
@@ -33,7 +33,7 @@
           "maxLength": 24
         },
         "status": {
-          "enum": ["active", "inactive"],
+          "enum": ["ACTIVE", "INACTIVE"],
           "title": "status"
         }
       },


### PR DESCRIPTION
Uppercase the Statement `status`