### PR TITLE
feat: add lens and farcaster to user profile

### DIFF
--- a/src/schemas/profile.json
+++ b/src/schemas/profile.json
@@ -39,6 +39,18 @@
           "title": "github",
           "pattern": "^[A-Za-z0-9_-]*$",
           "maxLength": 39
+        },
+        "lens": {
+          "type": "string",
+          "title": "lens",
+          "pattern": "^[A-Za-z0-9_]*$",
+          "maxLength": 26
+        },
+        "farcaster": {
+          "type": "string",
+          "title": "farcaster",
+          "pattern": "^[a-z0-9-]*$",
+          "maxLength": 17
         }
       },
       "required": [],


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/sx-monorepo/issues/406

Add `farcaster` and `lens` social network to user profile