### PR TITLE
fix: increase vote reason to 1000 chars

### DIFF
--- a/src/schemas/vote.json
+++ b/src/schemas/vote.json
@@ -27,7 +27,7 @@
         "reason": {
           "type": "string",
           "title": "reason",
-          "maxLength": 140
+          "maxLength": 1000
         },
         "app": {
           "type": "string",


### PR DESCRIPTION
This PR increase the max length of the vote reason to `1000`