### PR TITLE
fix: Use ENS name's resolver to get text record

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -537,7 +537,8 @@ export async function getEnsTextRecord(
   options: any = {}
 ) {
   const {
-    ensResolvers: ensResolversOpt = networks[network]?.ensResolvers || networks['1'].ensResolvers,
+    ensResolvers: ensResolversOpt = networks[network]?.ensResolvers ||
+      networks['1'].ensResolvers,
     broviderUrl,
     ...multicallOptions
   } = options;
@@ -547,7 +548,11 @@ export async function getEnsTextRecord(
 
   const calls = [
     [ENS_REGISTRY, 'resolver', [ensHash]], // Query for resolver from registry
-    ...ensResolversOpt.map((address: string) => [address, 'text', [ensHash, record]]) // Query for text record from each resolver
+    ...ensResolversOpt.map((address: string) => [
+      address,
+      'text',
+      [ensHash, record]
+    ]) // Query for text record from each resolver
   ];
 
   const [[resolverAddress], ...textRecords]: string[][] = await multicall(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -537,7 +537,7 @@ export async function getEnsTextRecord(
   options: any = {}
 ) {
   const {
-    ensResolvers: ensResolversOpt = networks[network]?.ensResolvers ||
+    ensResolvers = networks[network]?.ensResolvers ||
       networks['1'].ensResolvers,
     broviderUrl,
     ...multicallOptions
@@ -548,7 +548,7 @@ export async function getEnsTextRecord(
 
   const calls = [
     [ENS_REGISTRY, 'resolver', [ensHash]], // Query for resolver from registry
-    ...ensResolversOpt.map((address: string) => [
+    ...ensResolvers.map((address: string) => [
       address,
       'text',
       [ensHash, record]
@@ -563,7 +563,7 @@ export async function getEnsTextRecord(
     multicallOptions
   );
 
-  const resolverIndex = ensResolversOpt.indexOf(resolverAddress);
+  const resolverIndex = ensResolvers.indexOf(resolverAddress);
   return resolverIndex !== -1 ? textRecords[resolverIndex]?.[0] : null;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,8 +29,10 @@ interface Strategy {
   params: any;
 }
 
-const ENS_RESOLVER_ABI = [
-  'function text(bytes32 node, string calldata key) external view returns (string memory)'
+const ENS_REGISTRY = '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e';
+const ENS_ABI = [
+  'function text(bytes32 node, string calldata key) external view returns (string memory)',
+  'function resolver(bytes32 node) view returns (address)' // ENS registry ABI
 ];
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 
@@ -535,25 +537,29 @@ export async function getEnsTextRecord(
   options: any = {}
 ) {
   const {
-    ensResolvers: ensResolversOpt,
+    ensResolvers: ensResolversOpt = networks[network]?.ensResolvers || networks['1'].ensResolvers,
     broviderUrl,
     ...multicallOptions
   } = options;
-  const ensResolvers =
-    ensResolversOpt ||
-    networks[network].ensResolvers ||
-    networks['1'].ensResolvers;
+
   const ensHash = namehash(ensNormalize(ens));
   const provider = getProvider(network, { broviderUrl });
 
-  const result = await multicall(
+  const calls = [
+    [ENS_REGISTRY, 'resolver', [ensHash]], // Query for resolver from registry
+    ...ensResolversOpt.map((address: string) => [address, 'text', [ensHash, record]]) // Query for text record from each resolver
+  ];
+
+  const [[resolverAddress], ...textRecords]: string[][] = await multicall(
     network,
     provider,
-    ENS_RESOLVER_ABI,
-    ensResolvers.map((address: any) => [address, 'text', [ensHash, record]]),
+    ENS_ABI,
+    calls,
     multicallOptions
   );
-  return result.flat().find((r: string) => r) || '';
+
+  const resolverIndex = ensResolversOpt.indexOf(resolverAddress);
+  return resolverIndex !== -1 ? textRecords[resolverIndex]?.[0] : null;
 }
 
 export async function getSpaceUri(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -585,10 +585,9 @@ export async function getEnsOwner(
   network = '1',
   options: any = {}
 ): Promise<string | null> {
-  const registryAddress = '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e';
   const provider = getProvider(network, options);
   const ensRegistry = new Contract(
-    registryAddress,
+    ENS_REGISTRY,
     ['function owner(bytes32) view returns (address)'],
     provider
   );

--- a/test/e2e/utils/getScores.spec.ts
+++ b/test/e2e/utils/getScores.spec.ts
@@ -29,7 +29,7 @@ describe('test getScores', () => {
       data: ''
     });
   });
-  
+
   test('getScores should not pass API Key if it is passed in URL', async () => {
     expect.assertions(1);
     await expect(

--- a/test/schema.spec.ts
+++ b/test/schema.spec.ts
@@ -12,7 +12,6 @@ import schemas from '../src/schemas';
 import proposalMaxLengthWithSpaceTypeError from './examples/proposal-maxLengthWithSpaceType-error.json';
 import spaceMaxItemsWithSpaceTypeError from './examples/space-maxItemsWithSpaceType-error.json';
 
-
 describe.each([
   { schemaType: 'space', schema: schemas.space, example: space },
   { schemaType: 'proposal', schema: schemas.proposal, example: proposal },


### PR DESCRIPTION
### Summary

Right now we call both the old resolver and the new resolver to get the text record,
which is causing this issue: https://discord.com/channels/955773041898573854/1030772407226601522/1260542812106002526

This change will get the resolver of the ENS name and use that resolver's text record

### How to test:
- call getSpaceController before and after the fix
```ts
  snapshot.utils.getSpaceController('buzzedbears.eth', '1').then(console.log).catch(console.error);
```