### PR TITLE
fix: Rename livenet to mainnet

### DIFF
--- a/src/constants.json
+++ b/src/constants.json
@@ -1,5 +1,5 @@
 {
-  "livenet": {
+  "mainnet": {
     "hub": "https://hub.snapshot.org",
     "sequencer": "https://seq.snapshot.org"
   },

--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -57,10 +57,10 @@ export default class Client {
   readonly address: string;
   readonly options: any;
 
-  constructor(address: string = constants.livenet.sequencer, options = {}) {
+  constructor(address: string = constants.mainnet.sequencer, options = {}) {
     address = address.replace(
-      constants.livenet.hub,
-      constants.livenet.sequencer
+      constants.mainnet.hub,
+      constants.mainnet.sequencer
     );
     address = address.replace(
       constants.testnet.hub,


### PR DESCRIPTION
Right now it is `mainnet` in many places, so `livenet` keyword could be a cofusion