### PR TITLE
fix: Allow number inside domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/verify/index.ts
+++ b/src/verify/index.ts
@@ -6,7 +6,7 @@ import type { TypedDataField } from '@ethersproject/abstract-signer';
 import type { ProviderOptions } from '../utils/provider';
 
 export type SignaturePayload = {
-  domain: Record<string, string>;
+  domain: Record<string, string | number>;
   types: Record<string, StarkNetType[] | TypedDataField[]>;
   primaryType?: string;
   message: Record<string, any>;


### PR DESCRIPTION
Right now we only allow strings inside `domain` type, but in somecases, we do pass chainID as number: for example 

https://github.com/snapshot-labs/snapshot-relayer/blob/f6b8a4b8a22ef8c84da8a45b0d3d027635ee3d9e/src/api.ts#L32-L35
and 
https://github.com/snapshot-labs/snapshot.js/blob/921904924e6b671fa5392824b888f3180c780cf8/src/sign/index.ts#L86-L88
