### PR TITLE
fix: handle error when the ens is not valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -5,7 +5,9 @@ import {
   validateSchema,
   getScores,
   getVp,
-  getFormattedAddress
+  getFormattedAddress,
+  getEnsOwner,
+  getEnsTextRecord
 } from './utils';
 
 vi.mock('cross-fetch', async () => {
@@ -609,6 +611,20 @@ describe('utils', () => {
         address: ''
       });
       expect(result).not.toBe(true);
+    });
+  });
+
+  describe('getEnsOwner', () => {
+    test('should return null when the ENS is not valid', () => {
+      // special hidden characters after the k
+      expect(getEnsOwner('elonmusk‍‍.eth')).resolves.toBe(null);
+    });
+  });
+
+  describe('getEnsTextRecord', () => {
+    test('should return null when the ENS is not valid', () => {
+      // special hidden characters after the k
+      expect(getEnsTextRecord('elonmusk‍‍.eth')).resolves.toBe(null);
     });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -544,7 +544,14 @@ export async function getEnsTextRecord(
     ...multicallOptions
   } = options;
 
-  const ensHash = namehash(ensNormalize(ens));
+  let ensHash: string;
+
+  try {
+    ensHash = namehash(ensNormalize(ens));
+  } catch (e: any) {
+    return null;
+  }
+
   const provider = getProvider(network, { broviderUrl });
 
   const calls = [
@@ -592,9 +599,17 @@ export async function getEnsOwner(
     ['function owner(bytes32) view returns (address)'],
     provider
   );
+
+  let ensHash: string;
+
+  try {
+    ensHash = namehash(ensNormalize(ens));
+  } catch (e: any) {
+    return null;
+  }
+
   const ensNameWrapper =
     options.ensNameWrapper || networks[network].ensNameWrapper;
-  const ensHash = namehash(ensNormalize(ens));
   let owner = await ensRegistry.owner(ensHash);
   // If owner is the ENSNameWrapper contract, resolve the owner of the name
   if (owner === ensNameWrapper) {


### PR DESCRIPTION
Fix https://snapshot-labs.sentry.io/issues/5639825201/?query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=15

This PR will handle error, and return `null` when the given ENS name is not valid