### PR TITLE
feat: add support for cover image in space

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.12.9",
+  "version": "0.12.10",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -40,7 +40,13 @@
         "avatar": {
           "type": "string",
           "title": "avatar",
-          "format": "uri",
+          "format": "customUrl",
+          "maxLength": 256
+        },
+        "cover": {
+          "type": "string",
+          "title": "avatar",
+          "format": "customUrl",
           "maxLength": 256
         },
         "location": {


### PR DESCRIPTION
Working toward https://github.com/snapshot-labs/workflow/issues/152

This PR adds the `cover` property to the space settings, similar to the already existing one in Profile.