### PR TITLE
fix: Restrict treasuries items to be unique

### DIFF
--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -345,6 +345,7 @@
         "treasuries": {
           "type": "array",
           "maxItems": 10,
+          "uniqueItems": true,
           "items": {
             "type": "object",
             "properties": {


### PR DESCRIPTION
This change is similar to field `strategies`