### PR TITLE
fix: enforce lowecase valid hostname for space domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.12.13",
+  "version": "0.12.14",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -103,6 +103,10 @@
         },
         "domain": {
           "type": "string",
+          "allOf": [
+            { "format": "hostname" },
+            { "format": "lowercase" }
+          ],
           "title": "domain",
           "maxLength": 64
         },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -113,6 +113,10 @@ ajv.addFormat('long', {
   validate: () => true
 });
 
+ajv.addFormat('lowercase', {
+  validate: (value: string) => value === value.toLowerCase()
+});
+
 ajv.addFormat('ethValue', {
   validate: (value: string) => {
     if (!value.match(/^([0-9]|[1-9][0-9]+)(\.[0-9]+)?$/)) return false;

--- a/test/examples/space.json
+++ b/test/examples/space.json
@@ -16,6 +16,7 @@
   "network": "1",
   "plugins": {},
   "twitter": "lootproject",
+  "domain": "vote.lootproject.abc",
   "strategies": [
     {
       "name": "erc721",


### PR DESCRIPTION
From https://github.com/snapshot-labs/snapshot-sequencer/pull/439#discussion_r1773253485

This PR enforce that the `domain` property in space settings is a valid hostname, and always lowercase