### PR TITLE
feat: Validation for labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.12.16",
+  "version": "0.12.17",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -393,6 +393,41 @@
             "additionalProperties": false
           }
         },
+        "labels": {
+          "type": "array",
+          "maxItems": 100,
+          "uniqueItems": true,
+          "items":{
+            "type": "object",
+            "properties": {
+              "id":{
+                "type": "string",
+                "title": "Id",
+                "minLength": 1,
+                "maxLength": 8
+              },
+              "name": {
+                "type": "string",
+                "title": "Name",
+                "minLength": 1,
+                "maxLength": 32
+              },
+              "description": {
+                "type": "string",
+                "title": "Description",
+                "minLength": 1,
+                "maxLength": 100
+              },
+              "color": {
+                "type": "string",
+                "title": "Color",
+                "format": "color"
+              }
+            },
+            "required": ["id", "name", "description", "color"],
+            "additionalProperties": false
+          }
+        },
         "parent": {
           "type": "string",
           "title": "parent"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,7 +120,7 @@ ajv.addFormat('lowercase', {
 ajv.addFormat('color', {
   validate: (value: string) => {
     if (!value) return false;
-    return !!value.match(/^#[0-9a-fA-F]{6}$/);
+    return !!value.match(/^#[0-9A-F]{6}$/);
   }
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -117,6 +117,13 @@ ajv.addFormat('lowercase', {
   validate: (value: string) => value === value.toLowerCase()
 });
 
+ajv.addFormat('color', {
+  validate: (value: string) => {
+    if (!value) return false;
+    return !!value.match(/^#[0-9a-fA-F]{6}$/);
+  }
+});
+
 ajv.addFormat('ethValue', {
   validate: (value: string) => {
     if (!value.match(/^([0-9]|[1-9][0-9]+)(\.[0-9]+)?$/)) return false;

--- a/test/examples/space.json
+++ b/test/examples/space.json
@@ -30,9 +30,23 @@
     "name": "basic",
     "params": {}
   },
-  "voting":{
+  "voting": {
     "delay": 2592000,
     "period": 15552000,
     "quorum": 100
-  }
+  },
+  "labels": [
+    {
+        "id": "4b6a8c88",
+        "name": "Test 1",
+        "description": "Test Description 1",
+        "color": "#48CB0D"
+    },
+    {
+        "id": "893b2f3",
+        "name": "Test 2",
+        "description": "Test Description 2",
+        "color": "#FBE54E"
+    }
+  ]
 }


### PR DESCRIPTION
Towards https://github.com/snapshot-labs/workflow/issues/143

### Summary:
- Validation for labels
- Allows 100 labels with `id`, `name`, `description` and `color`


### How to test:
- Run `yarn test`
- Try changing values in test/examples/space.json