### PR TITLE
fix: Labels description field as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.12.18",
+  "version": "0.12.19",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -415,7 +415,6 @@
               "description": {
                 "type": "string",
                 "title": "Description",
-                "minLength": 1,
                 "maxLength": 100
               },
               "color": {
@@ -424,7 +423,7 @@
                 "format": "color"
               }
             },
-            "required": ["id", "name", "description", "color"],
+            "required": ["id", "name", "color"],
             "additionalProperties": false
           }
         },

--- a/test/examples/space.json
+++ b/test/examples/space.json
@@ -45,7 +45,6 @@
     {
         "id": "893b2f3",
         "name": "Test 2",
-        "description": "Test Description 2",
         "color": "#FBE54E"
     }
   ]


### PR DESCRIPTION
Continued from https://github.com/snapshot-labs/snapshot.js/pull/1062

### Summary:
- To make it the same as GitHub

### How to test:
- Run `yarn test`
- Try changing values in test/examples/space.json