### PR TITLE
fix: allow starknet treasury address

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.12.20",
+  "version": "0.12.21",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -378,9 +378,10 @@
                 "type": "string",
                 "title": "Contract address",
                 "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
-                "pattern": "^0x[a-fA-F0-9]{40}$",
-                "minLength": 42,
-                "maxLength": 42
+                "anyOf": [
+                  { "format": "address" },
+                  { "format": "starknetAddress" }
+                ]
               },
               "network": {
                 "type": "string",


### PR DESCRIPTION
Fix https://github.com/snapshot-labs/sx-monorepo/pull/840

Allow starknet treasury address
