### PR TITLE
fix: loosen some address validation to accept lowercase

### DIFF
--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -147,9 +147,7 @@
           "maxItems": 100,
           "items": {
             "type": "string",
-            "pattern": "^0x[a-fA-F0-9]{40}$",
-            "minLength": 42,
-            "maxLength": 42
+            "format": "evmAddress"
           },
           "title": "members",
           "uniqueItems": true
@@ -159,9 +157,7 @@
           "maxItems": 100,
           "items": {
             "type": "string",
-            "pattern": "^0x[a-fA-F0-9]{40}$",
-            "minLength": 42,
-            "maxLength": 42
+            "format": "evmAddress"
           },
           "title": "admins",
           "uniqueItems": true
@@ -171,9 +167,7 @@
           "maxItems": 100,
           "items": {
             "type": "string",
-            "pattern": "^0x[a-fA-F0-9]{40}$",
-            "minLength": 42,
-            "maxLength": 42
+            "format": "evmAddress"
           },
           "title": "moderators",
           "uniqueItems": true
@@ -264,7 +258,7 @@
             },
             "delegationContract": {
               "type": "string",
-              "format": "address",
+              "format": "evmAddress",
               "title": "Contract address",
               "description": "The address of your delegation contract",
               "examples": ["0x3901D0fDe202aF1427216b79f5243f8A022d68cf"]
@@ -379,7 +373,7 @@
                 "title": "Contract address",
                 "examples": ["e.g. 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984"],
                 "anyOf": [
-                  { "format": "address" },
+                  { "format": "evmAddress" },
                   { "format": "starknetAddress" }
                 ]
               },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -99,6 +99,17 @@ ajv.addFormat('address', {
   }
 });
 
+ajv.addFormat('evmAddress', {
+  validate: (value: string) => {
+    try {
+      getAddress(value);
+      return true;
+    } catch (e: any) {
+      return false;
+    }
+  }
+});
+
 ajv.addFormat('starknetAddress', {
   validate: (value: string) => {
     try {

--- a/test/examples/space.json
+++ b/test/examples/space.json
@@ -35,6 +35,23 @@
     "period": 15552000,
     "quorum": 100
   },
+  "treasuries": [
+    {
+      "name": "EVM treasury with checksummed address",
+      "address": "0xF296178d553C8Ec21A2fBD2c5dDa8CA9ac905A00",
+      "network": "1"
+    },
+    {
+      "name": "EVM treasury with lowercase address",
+      "address": "0xf296178d553c8ec21a2fbd2c5dda8ca9ac905a00",
+      "network": "1"
+    },
+    {
+      "name": "Starknet treasury",
+      "address": "0x05702362b68a350c1cae8f2a529d74fdbb502369ddcebfadac7e91da37636947",
+      "network": "1"
+    }
+  ],
   "labels": [
     {
         "id": "4b6a8c88",


### PR DESCRIPTION
This PR:

- add a new `evmAddress` validation, which accept checksummed and lowercase EVM address (existing `address` validation is only accepting checksummed address)
- Migrate existing regex address validation to use `evmAddress` 
- Migrate `delegationPortalNetwork` from `address` to `evmAddress` (this is used only on v2, which does not enforce checksummed address)
- Migrate recently treasuries address to also accept lowercase address