### PR TITLE
feat: add support for starknet treasuries and delegations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.12.22",
+  "version": "0.12.23",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -285,7 +285,7 @@
               ]
             }
           },
-          "required": ["delegationType", "delegationApi", "delegationContract"],
+          "required": ["delegationType","delegationNetwork", "delegationApi", "delegationContract"],
           "additionalProperties": false
         },
         "allowAlias": {

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -258,18 +258,22 @@
             },
             "delegationContract": {
               "type": "string",
-              "format": "evmAddress",
               "title": "Contract address",
               "description": "The address of your delegation contract",
-              "examples": ["0x3901D0fDe202aF1427216b79f5243f8A022d68cf"]
+              "examples": ["0x3901D0fDe202aF1427216b79f5243f8A022d68cf"],
+              "anyOf": [
+                { "format": "evmAddress" },
+                { "format": "starknetAddress" }
+              ]
             },
             "delegationNetwork": {
               "type": "string",
-              "snapshotNetwork": true,
               "title": "Delegation network",
-              "minLength": 1,
-              "maxLength": 32,
-              "description": "The network of your delegation contract"
+              "description": "The network of your delegation contract",
+              "anyOf": [
+                { "snapshotNetwork": true },
+                { "starknetNetwork": true }
+              ]
             },
             "delegationApi": {
               "type": "string",
@@ -379,9 +383,11 @@
               },
               "network": {
                 "type": "string",
-                "snapshotNetwork": true,
                 "title": "Network",
-                "maxLength": 12
+                "anyOf": [
+                { "snapshotNetwork": true },
+                { "starknetNetwork": true }
+              ]
               }
             },
             "required": ["name", "address", "network"],

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -285,7 +285,7 @@
               ]
             }
           },
-          "required": ["delegationType","delegationNetwork", "delegationApi", "delegationContract"],
+          "required": ["delegationType", "delegationNetwork", "delegationApi", "delegationContract"],
           "additionalProperties": false
         },
         "allowAlias": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,6 +36,7 @@ const ENS_ABI = [
   'function resolver(bytes32 node) view returns (address)' // ENS registry ABI
 ];
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
+const STARKNET_NETWORKS = ['0x534e5f4d41494e', '0x534e5f5345504f4c4941'];
 
 const scoreApiHeaders = {
   Accept: 'application/json',
@@ -160,6 +161,16 @@ ajv.addKeyword({
     const snapshotEnv = this.snapshotEnv || 'default';
     if (snapshotEnv === 'mainnet') return mainnetNetworkIds.includes(data);
     return networksIds.includes(data);
+  },
+  error: {
+    message: 'network not allowed'
+  }
+});
+
+ajv.addKeyword({
+  keyword: 'starknetNetwork',
+  validate: function (schema, data) {
+    return STARKNET_NETWORKS.includes(data);
   },
   error: {
     message: 'network not allowed'

--- a/test/examples/space-starknet-delegation.json
+++ b/test/examples/space-starknet-delegation.json
@@ -1,0 +1,44 @@
+{
+  "name": "Loot Owners",
+  "skin": "indexed",
+  "about": "",
+  "admins": [
+    "0xF296178d553C8Ec21A2fBD2c5dDa8CA9ac905A00"
+  ],
+  "avatar": "https://pbs.twimg.com/profile_images/1431587138202701826/lpgblc4h_400x400.jpg",
+  "github": "lootproject",
+  "symbol": "LOOT",
+  "filters": {
+    "minScore": 1,
+    "onlyMembers": false
+  },
+  "members": [],
+  "network": "1",
+  "plugins": {},
+  "twitter": "lootproject",
+  "domain": "vote.lootproject.abc",
+  "strategies": [
+    {
+      "name": "erc721",
+      "params": {
+        "symbol": "LOOT",
+        "address": "0xff9c1b15b16263c61d017ee9f65c50e4ae0113d7"
+      }
+    }
+  ],
+  "delegationPortal":{
+    "delegationType": "compound-governor",
+    "delegationContract": "0x05702362b68a350c1cae8f2a529d74fdbb502369ddcebfadac7e91da37636947",
+    "delegationNetwork": "0x534e5f4d41494e",
+    "delegationApi": "https://snapshot.org"
+  },
+  "validation": {
+    "name": "basic",
+    "params": {}
+  },
+  "voting": {
+    "delay": 2592000,
+    "period": 15552000,
+    "quorum": 100
+  }
+}

--- a/test/examples/space.json
+++ b/test/examples/space.json
@@ -47,9 +47,14 @@
       "network": "1"
     },
     {
-      "name": "Starknet treasury",
+      "name": "Mainnet Starknet treasury",
       "address": "0x05702362b68a350c1cae8f2a529d74fdbb502369ddcebfadac7e91da37636947",
-      "network": "1"
+      "network": "0x534e5f4d41494e"
+    },
+    {
+      "name": "Sepolia Starknet treasury",
+      "address": "0x05702362b68a350c1cae8f2a529d74fdbb502369ddcebfadac7e91da37636947",
+      "network": "0x534e5f5345504f4c4941"
     }
   ],
   "labels": [

--- a/test/schema.spec.ts
+++ b/test/schema.spec.ts
@@ -3,6 +3,7 @@ import { validateSchema } from '../src/utils';
 import space from './examples/space.json';
 import proposal from './examples/proposal.json';
 import spaceTurbo from './examples/space-turbo.json';
+import spaceStarknetDelegation from './examples/space-starknet-delegation.json';
 import proposalTurbo from './examples/proposal-turbo.json';
 import vote from './examples/vote.json';
 import profile from './examples/profile.json';
@@ -15,6 +16,11 @@ import spaceMaxItemsWithSpaceTypeError from './examples/space-maxItemsWithSpaceT
 // Tests for default spaces
 describe.each([
   { schemaType: 'space', schema: schemas.space, example: space },
+  {
+    schemaType: 'space',
+    schema: schemas.space,
+    example: spaceStarknetDelegation
+  },
   { schemaType: 'proposal', schema: schemas.proposal, example: proposal },
   { schemaType: 'vote', schema: schemas.vote, example: vote },
   { schemaType: 'profile', schema: schemas.profile, example: profile },


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/sx-monorepo/pull/851
Continuing https://github.com/snapshot-labs/snapshot.js/pull/1066#issuecomment-2399931257

This PR adds support for starknet addresses and network for delegations and treasuries