### PR TITLE
fix: add meaninful error message for anyof validation

### DIFF
--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -274,7 +274,8 @@
               "anyOf": [
                 { "snapshotNetwork": true },
                 { "starknetNetwork": true }
-              ]
+              ],
+              "errorMessage": "Must be a valid network"
             },
             "delegationApi": {
               "type": "string",
@@ -389,7 +390,8 @@
                 "anyOf": [
                 { "snapshotNetwork": true },
                 { "starknetNetwork": true }
-              ]
+              ],
+              "errorMessage": "Must be a valid network"
               }
             },
             "required": ["name", "address", "network"],

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -264,7 +264,8 @@
               "anyOf": [
                 { "format": "evmAddress" },
                 { "format": "starknetAddress" }
-              ]
+              ],
+              "errorMessage": "Must be a valid EVM of Starknet address"
             },
             "delegationNetwork": {
               "type": "string",
@@ -379,7 +380,8 @@
                 "anyOf": [
                   { "format": "evmAddress" },
                   { "format": "starknetAddress" }
-                ]
+                ],
+                "errorMessage": "Must be a valid EVM of Starknet address"
               },
               "network": {
                 "type": "string",


### PR DESCRIPTION
This PR fixes the error message for validation with `anyOf`, which were showing `Must match a schema in anyOf.`

This PR adds a more meaningful error message for validation using `anyOf`