### PR TITLE
fix: filter out starknet testnet on mainnet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.12.23",
+  "version": "0.12.24",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,7 +36,16 @@ const ENS_ABI = [
   'function resolver(bytes32 node) view returns (address)' // ENS registry ABI
 ];
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
-const STARKNET_NETWORKS = ['0x534e5f4d41494e', '0x534e5f5345504f4c4941'];
+const STARKNET_NETWORKS = {
+  '0x534e5f4d41494e': {
+    name: 'Starknet',
+    testnet: false
+  },
+  '0x534e5f5345504f4c4941': {
+    name: 'Starknet Sepolia',
+    testnet: true
+  }
+};
 
 const scoreApiHeaders = {
   Accept: 'application/json',
@@ -170,7 +179,15 @@ ajv.addKeyword({
 ajv.addKeyword({
   keyword: 'starknetNetwork',
   validate: function (schema, data) {
-    return STARKNET_NETWORKS.includes(data);
+    // @ts-ignore
+    const snapshotEnv = this.snapshotEnv || 'default';
+    if (snapshotEnv === 'mainnet') {
+      return Object.keys(STARKNET_NETWORKS)
+        .filter((id) => !STARKNET_NETWORKS[id].testnet)
+        .includes(data);
+    }
+
+    return Object.keys(STARKNET_NETWORKS).includes(data);
   },
   error: {
     message: 'network not allowed'

--- a/test/examples/space.json
+++ b/test/examples/space.json
@@ -50,11 +50,6 @@
       "name": "Mainnet Starknet treasury",
       "address": "0x05702362b68a350c1cae8f2a529d74fdbb502369ddcebfadac7e91da37636947",
       "network": "0x534e5f4d41494e"
-    },
-    {
-      "name": "Sepolia Starknet treasury",
-      "address": "0x05702362b68a350c1cae8f2a529d74fdbb502369ddcebfadac7e91da37636947",
-      "network": "0x534e5f5345504f4c4941"
     }
   ],
   "labels": [


### PR DESCRIPTION
Following on https://github.com/snapshot-labs/snapshot.js/pull/1069

This PR do not validate starknet testnet on mainnet, like for the regular network selector