### PR TITLE
fix: make delegationNetwork optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.12.24",
+  "version": "0.12.25",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -287,7 +287,7 @@
               ]
             }
           },
-          "required": ["delegationType", "delegationNetwork", "delegationApi", "delegationContract"],
+          "required": ["delegationType", "delegationApi", "delegationContract"],
           "additionalProperties": false
         },
         "allowAlias": {


### PR DESCRIPTION
This PR change the delegation network to be optional (will set a default on sequencer before saving)