### PR TITLE
fix: Allow https in domain

### DIFF
--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -103,12 +103,9 @@
         },
         "domain": {
           "type": "string",
-          "allOf": [
-            { "format": "hostname" },
-            { "format": "lowercase" }
-          ],
           "title": "domain",
-          "maxLength": 64
+          "maxLength": 64,
+          "format": "domain"
         },
         "strategies": {
           "type": "array",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -252,6 +252,13 @@ ajv.addFormat('customUrl', {
   }
 });
 
+ajv.addFormat('domain', {
+  validate: (value: string) => {
+    if (!value) return false;
+    return !!value.match(/^(https:\/\/)?([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$/);
+  }
+});
+
 export async function call(provider, abi: any[], call: any[], options?) {
   const contract = new Contract(call[0], abi, provider);
   try {

--- a/test/examples/space-starknet-delegation.json
+++ b/test/examples/space-starknet-delegation.json
@@ -16,7 +16,7 @@
   "network": "1",
   "plugins": {},
   "twitter": "lootproject",
-  "domain": "vote.lootproject.abc",
+  "domain": "https://vote.lootproject.abc",
   "strategies": [
     {
       "name": "erc721",


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/workflow/issues/253

Allow https in domain 


### How to test:
- Run `yarn test`
- Edit test/examples/space.json with different domain values