### PR TITLE
fix: Allow slash at domain end

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -255,7 +255,9 @@ ajv.addFormat('customUrl', {
 ajv.addFormat('domain', {
   validate: (value: string) => {
     if (!value) return false;
-    return !!value.match(/^(https:\/\/)?([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$/);
+    return !!value.match(
+      /^(https:\/\/)?([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}(\/)?$/
+    );
   }
 });
 


### PR DESCRIPTION
Continued from https://github.com/snapshot-labs/snapshot.js/pull/1074

### How to test: 
- Run `yarn test`
- Edit `test/examples/space.json` with different domain values