### PR TITLE
revert: revert app chars max length

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.12.26",
+  "version": "0.12.28",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.12.27",
+  "version": "0.12.26",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/schemas/proposal.json
+++ b/src/schemas/proposal.json
@@ -83,7 +83,7 @@
         "app": {
           "type": "string",
           "title": "app",
-          "maxLength": 128
+          "maxLength": 24
         }
       },
       "required": ["name", "body", "choices", "snapshot", "start", "end"],

--- a/src/schemas/vote.json
+++ b/src/schemas/vote.json
@@ -32,7 +32,7 @@
         "app": {
           "type": "string",
           "title": "app",
-          "maxLength": 128
+          "maxLength": 24
         }
       },
       "required": [


### PR DESCRIPTION
This PR revert https://github.com/snapshot-labs/snapshot.js/pull/1077 which is stuck because of slow database update

For now, the feature will move on with orignal char limit