### PR TITLE
feat: increase vote reason length to 5000

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.12.27",
+  "version": "0.12.28",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/schemas/vote.json
+++ b/src/schemas/vote.json
@@ -27,7 +27,7 @@
         "reason": {
           "type": "string",
           "title": "reason",
-          "maxLength": 1000
+          "maxLength": 5000
         },
         "app": {
           "type": "string",


### PR DESCRIPTION
Towards https://github.com/snapshot-labs/workflow/issues/260

Changes proposed in this pull request:
- Increase Vote's `reason` max length to 5000.
