### PR TITLE
feat: add discussion link and discourse category to space schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.12.33",
+  "version": "0.12.34",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -107,6 +107,17 @@
           "maxLength": 64,
           "format": "domain"
         },
+        "discussionLink": {
+          "type": "string",
+          "format": "uri",
+          "title": "Discussion link",
+          "maxLength": 256
+        },
+        "discourseCategory": {
+          "type": "integer",
+          "minimum": 1,
+          "title": "Discourse category"
+        },
         "strategies": {
           "type": "array",
           "minItems": 1,

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -110,7 +110,7 @@
         "discussions": {
           "type": "string",
           "format": "uri",
-          "title": "Discussion link",
+          "title": "Discussions link",
           "maxLength": 256
         },
         "discourseCategory": {

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -107,7 +107,7 @@
           "maxLength": 64,
           "format": "domain"
         },
-        "discussionLink": {
+        "discussions": {
           "type": "string",
           "format": "uri",
           "title": "Discussion link",

--- a/test/examples/space.json
+++ b/test/examples/space.json
@@ -16,7 +16,7 @@
   "network": "1",
   "plugins": {},
   "twitter": "lootproject",
-  "discussionLink": "https://discuss.ens.domains/",
+  "discussions": "https://discuss.ens.domains/",
   "discourseCategory": 28,
   "domain": "vote.lootproject.abc",
   "strategies": [

--- a/test/examples/space.json
+++ b/test/examples/space.json
@@ -16,6 +16,8 @@
   "network": "1",
   "plugins": {},
   "twitter": "lootproject",
+  "discussionLink": "https://discuss.ens.domains/",
+  "discourseCategory": 28,
   "domain": "vote.lootproject.abc",
   "strategies": [
     {


### PR DESCRIPTION
Towards https://github.com/snapshot-labs/workflow/issues/275

### Summary:
- Add new fields  `discussionLink` and `discourseCategory` to space

### How to test:
- Run `yarn test` 
- change values in `test/examples/space.json`