### PR TITLE
revert: reverting app length increase

### DIFF
--- a/src/schemas/proposal.json
+++ b/src/schemas/proposal.json
@@ -83,7 +83,7 @@
         "app": {
           "type": "string",
           "title": "app",
-          "maxLength": 128
+          "maxLength": 24
         },
         "privacy": {
           "type": "string",

--- a/src/schemas/vote.json
+++ b/src/schemas/vote.json
@@ -32,7 +32,7 @@
         "app": {
           "type": "string",
           "title": "app",
-          "maxLength": 128
+          "maxLength": 24
         }
       },
       "required": [


### PR DESCRIPTION
Reverting of https://github.com/snapshot-labs/snapshot.js/pull/1077

Reverting the length increase, as not easily feasible on the database side, see https://github.com/snapshot-labs/snapshot-sequencer/pull/463