### PR TITLE
feat: make symbol optional

### DIFF
--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -467,7 +467,7 @@
           "additionalProperties": false
         }
       },
-      "required": ["name", "network", "symbol", "strategies"],
+      "required": ["name", "network", "strategies"],
       "additionalProperties": false
     }
   }


### PR DESCRIPTION
Fixes https://github.com/snapshot-labs/sx-monorepo/issues/1098

This PR will make the `symbol` property optional in the space settings (and allow blank VO symbol)