### PR TITLE
fix: remove min length validation from space symbol

### DIFF
--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -93,7 +93,6 @@
         "symbol": {
           "type": "string",
           "title": "symbol",
-          "minLength": 1,
           "maxLength": 16
         },
         "skin": {


### PR DESCRIPTION
This PR will make the symbol property on Space truly optional, by removing the min length validation