### PR TITLE
feat: add skin colors to space settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.12.44",
+  "version": "0.12.45",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -476,7 +476,7 @@
           "required": ["enabled", "bribeEnabled"],
           "additionalProperties": false
         },
-        "colors": {
+        "skinParams": {
           "type": "object",
           "properties": {
             "bg_color": {

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -475,6 +475,48 @@
           },
           "required": ["enabled", "bribeEnabled"],
           "additionalProperties": false
+        },
+        "colors": {
+          "type": "object",
+          "properties": {
+            "bg_color": {
+              "type": "string",
+              "format": "color"
+            },
+            "link_color": {
+              "type": "string",
+              "format": "color"
+            },
+            "text_color": {
+              "type": "string",
+              "format": "color"
+            },
+            "content_color": {
+              "type": "string",
+              "format": "color"
+            },
+            "border_color" : {
+              "type": "string",
+              "format": "color"
+            },
+            "heading_color" : {
+              "type": "string",
+             "format": "color"
+            },
+            "primary_color": {
+              "type": "string",
+              "format": "color"
+            },
+            "header_color": {
+              "type": "string",
+              "format": "color"
+            },
+            "theme": {
+              "type": "string",
+              "enum": ["light", "dark"]
+            }
+          },
+          "additionalProperties": false
         }
       },
       "required": ["name", "network", "strategies"],

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -513,6 +513,12 @@
             "theme": {
               "type": "string",
               "enum": ["light", "dark"]
+            },
+            "logo": {
+              "type": "string",
+              "title": "logo",
+              "format": "customUrl",
+              "maxLength": 256
             }
           },
           "additionalProperties": false

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -475,7 +475,7 @@
           "required": ["enabled", "bribeEnabled"],
           "additionalProperties": false
         },
-        "skinParams": {
+        "skinSettings": {
           "type": "object",
           "properties": {
             "bg_color": {


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/418

This PR adds the skin colors to space schema

To be tested together with https://github.com/snapshot-labs/snapshot-sequencer/pull/497