### PR TITLE
feat: add logo to skin params

### DIFF
--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -513,6 +513,12 @@
             "theme": {
               "type": "string",
               "enum": ["light", "dark"]
+            },
+            "logo": {
+              "type": "string",
+              "title": "logo",
+              "format": "customUrl",
+              "maxLength": 256
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/416
Depends on https://github.com/snapshot-labs/snapshot.js/pull/1119

This PR will add a new `logo` property to the `skinParams` object, to store white label custom logo