### PR TITLE
chore: update Mantle explorer to Mantlescan

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.12.47",
+  "version": "0.12.48",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/networks.json
+++ b/src/networks.json
@@ -1103,7 +1103,7 @@
       "https://rpc.mantle.xyz"
     ],
     "explorer": {
-      "url": "https://explorer.mantle.xyz"
+      "url": "https://mantlescan.xyz"
     },
     "start": 304717,
     "logo": "ipfs://bafkreidkucwfn4mzo2gtydrt2wogk3je5xpugom67vhi4h4comaxxjzoz4"


### PR DESCRIPTION
Changes proposed in this pull request:
- Change explorer to Mantlescan from https://explorer.mantle.xyz/ - current explorer tends to throw 404 for results and only shows data after refresh.
