### PR TITLE
feat: return space controller for .shib names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.12.57",
+  "version": "0.12.58",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -716,9 +716,9 @@ export async function getEnsOwner(
   return owner || EMPTY_ADDRESS;
 }
 
-export async function getSpaceController(
+async function getEnsSpaceController(
   id: string,
-  network = '1',
+  network: string,
   options: any = {}
 ): Promise<string> {
   const spaceUri = await getSpaceUri(id, network, options);
@@ -733,6 +733,39 @@ export async function getSpaceController(
     if (isUriAddress) return address;
   }
   return await getEnsOwner(id, network, options);
+}
+
+export async function getShibariumNameOwner(
+  id: string,
+  network: string
+): Promise<string> {
+  if (!id.endsWith('.shib')) {
+    return EMPTY_ADDRESS;
+  }
+
+  const response = await fetch(
+    `https://bens.services.blockscout.com/api/v1/${network}/domains:lookup?name=${id}&only_active=true`,
+    {
+      headers: { 'Content-Type': 'application/json' }
+    }
+  );
+  const data = await response.json();
+
+  return data.items[0]?.owner?.hash || EMPTY_ADDRESS;
+}
+
+export async function getSpaceController(
+  id: string,
+  network = '1',
+  options: any = {}
+): Promise<string> {
+  if (['1', '11155111'].includes(network)) {
+    return getEnsSpaceController(id, network, options);
+  } else if (['109', '157'].includes(network)) {
+    return getShibariumNameOwner(id, network);
+  }
+
+  throw new Error(`Network not supported: ${network}`);
 }
 
 export function clone(item) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -743,20 +743,20 @@ export async function getShibariumNameOwner(
     return EMPTY_ADDRESS;
   }
 
-  const response = await fetch(
-    `https://bens.services.blockscout.com/api/v1/${network}/domains:lookup?name=${id}&only_active=true`,
-    {
-      headers: { 'Content-Type': 'application/json' }
-    }
-  );
-  if (!response.ok) {
-    throw new Error(
-      `Shibarium API error: [${response.status}] ${response.statusText}`
-    );
-  }
-  const data = await response.json();
+  const response = await fetch('https://stamp.fyi', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      method: 'get_owner',
+      params: id,
+      network
+    })
+  });
 
-  return data.items[0]?.owner?.hash || EMPTY_ADDRESS;
+  const data = await response.json();
+  return data.result;
 }
 
 export async function getSpaceController(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -749,6 +749,11 @@ export async function getShibariumNameOwner(
       headers: { 'Content-Type': 'application/json' }
     }
   );
+  if (!response.ok) {
+    throw new Error(
+      `Shibarium API error: [${response.status}] ${response.statusText}`
+    );
+  }
   const data = await response.json();
 
   return data.items[0]?.owner?.hash || EMPTY_ADDRESS;

--- a/test/e2e/utils.spec.js
+++ b/test/e2e/utils.spec.js
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest';
-import { getEnsOwner } from '../../src/utils';
+import { getEnsOwner, getShibariumNameOwner } from '../../src/utils';
 
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 
@@ -70,6 +70,26 @@ describe('utils', () => {
 
       test('return an empty address for unclaimed domain', () => {
         expect(getEnsOwner('google.com')).resolves.toBe(EMPTY_ADDRESS);
+      });
+    });
+
+    describe('shibarium resolver', () => {
+      test('return an empty address for unrecognized extension', () => {
+        expect(getShibariumNameOwner('invalid.domain', '109')).resolves.toBe(
+          EMPTY_ADDRESS
+        );
+      });
+
+      test('return the name owner on mainnet', () => {
+        expect(getShibariumNameOwner('boorger.shib', '109')).resolves.toBe(
+          '0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6'
+        );
+      });
+
+      test('return the name owner on testnet', () => {
+        expect(
+          getShibariumNameOwner('systematize752253.shib', '157')
+        ).resolves.toBe('0xc4B06a671831CdD66fdA1A287263103103DEC80D');
       });
     });
   });


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/523

This PR will return the space controller for .shib names, for both their mainnet and testnet.

~~As of now, they don't have an official api for returning name owner, it's using the same api service as their name service lookup (https://www.shibariumscan.io/name-domains)~~

PR updated to use d3 (their name partner) api to return names info.