### PR TITLE
fix: add verifyinContract to eip-712 signature

### DIFF
--- a/src/sign/index.ts
+++ b/src/sign/index.ts
@@ -47,10 +47,12 @@ export const domain: {
   name: string;
   version: string;
   chainId?: number;
+  verifyingContract: string;
 } = {
   name: NAME,
-  version: VERSION
+  version: VERSION,
   // chainId: 1
+  verifyingContract: '0x0000000000000000000000000000000000000000'
 };
 
 export default class Client {


### PR DESCRIPTION
This PR aims to fix [this bug](https://github.com/MetaMask/metamask-extension/issues/31606) that seems not to be handling the EIP-712 signature when connected to a metamask wallet.

A verifying contract argument could be passed to the function in case a real one is needed, but it would change the function signature.