### PR TITLE
feat: accept starknet address when fetching vp or validation

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -794,7 +794,10 @@ function isValidNetwork(network: string) {
 }
 
 function isValidAddress(address: string) {
-  return isAddress(address) && address !== EMPTY_ADDRESS;
+  return (
+    (isAddress(address) || isStarknetAddress(address)) &&
+    address !== EMPTY_ADDRESS
+  );
 }
 
 function isValidSnapshot(snapshot: number | string, network: string) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -795,8 +795,8 @@ function isValidNetwork(network: string) {
 
 function isValidAddress(address: string) {
   return (
-    (isAddress(address) || isStarknetAddress(address)) &&
-    address !== EMPTY_ADDRESS
+    address !== EMPTY_ADDRESS &&
+    (isAddress(address) || isStarknetAddress(address))
   );
 }
 


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/562

This PR allows starknet addresses when calling `get_vp`, `validate` and `getScores`