### PR TITLE
feat: add RPC URLs for Shibarium mainnet (109) and Puppynet testnet (157)

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -317,7 +317,10 @@
     "chainId": 109,
     "network": "mainnet",
     "multicall": "0xcA11bde05977b3631167028862bE2a173976CA11",
-    "rpc": [],
+    "rpc": [
+            "https://www.shibrpc.com",
+            "https://rpc.shibrpc.com"
+          ],
     "explorer": {
       "url": "https://shibariumscan.io"
     },
@@ -415,7 +418,7 @@
     "chainId": 157,
     "network": "testnet",
     "multicall": "0xA4029b74FBA366c926eDFA7Dd10B21C621170a4c",
-    "rpc": [],
+    "rpc": ["https://puppynet.shibrpc.com"],
     "explorer": {
       "url": "https://puppyscan.shib.io"
     },


### PR DESCRIPTION
This PR adds public RPC URLs for both Shibarium mainnet (chain ID 109) and Puppynet testnet (chain ID 157) to the `networks.json` configuration file in `snapshot.js`.

Adding these RPC endpoints enables Snapshot strategies and tooling to properly query on-chain data from Shibarium networks, allowing DAOs and voting mechanisms on these chains to function correctly.

**Changes include:**

* Added two public RPC URLs for Shibarium mainnet (109):

  * `https://www.shibrpc.com`
  * `https://rpc.shibrpc.com`
  
* Added a public RPC URL for Puppynet testnet (157):
  * `https://puppynet.shibrpc.com`

This will help improve Snapshot's compatibility with Shibarium and Puppynet, supporting developers and communities building on these chain