### PR TITLE
fix: accept both lowercase and checksum starknet address as valid

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -132,7 +132,9 @@ ajv.addFormat('evmAddress', {
 ajv.addFormat('starknetAddress', {
   validate: (value: string) => {
     try {
-      return validateAndParseAddress(value) === value;
+      return (
+        validateAndParseAddress(value).toLowerCase() === value.toLowerCase()
+      );
     } catch (e: any) {
       return false;
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -132,6 +132,8 @@ ajv.addFormat('evmAddress', {
 ajv.addFormat('starknetAddress', {
   validate: (value: string) => {
     try {
+      // Accept both checksum and lowercase addresses
+      // but need to always be padded
       return (
         validateAndParseAddress(value).toLowerCase() === value.toLowerCase()
       );


### PR DESCRIPTION
This PR loosen the starknet address validator, to accept both checksum (current) and lowercase (new) addresses as valid. It stil require that addresses are fully padded.,

This will align with the `evmAddress` validation, which is currently accepting both lowercase and checksum.

Without this patch, the validator will reject all checksum starknet address. In the ui side, we don't check for case when sending starknet address (like adding member in the space settings), so valid data on the UI will be rejected by sequencer.