### PR TITLE
feat: accept starknet networks in all networks field

### DIFF
--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -85,7 +85,11 @@
         },
         "network": {
           "type": "string",
-          "snapshotNetwork": true,
+          "anyOf": [
+            { "snapshotNetwork": true },
+            { "starknetNetwork": true }
+          ],
+          "errorMessage": "Must be a valid network",
           "title": "network",
           "minLength": 1,
           "maxLength": 32
@@ -133,7 +137,11 @@
                 "type": "string",
                 "maxLength": 12,
                 "title": "network",
-                "snapshotNetwork": true
+                "anyOf": [
+                  { "snapshotNetwork": true },
+                  { "starknetNetwork": true }
+                ],
+                "errorMessage": "Must be a valid network"
               },
               "params": {
                 "type": "object",


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/562

This PR allows starknet network in:

- all strategies `network` field
- space `network` field