### PR TITLE
feat: add farcaster handle to space profile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.12.63",
+  "version": "0.12.64",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -78,6 +78,12 @@
           "pattern": "^[A-Za-z0-9_-]*$",
           "maxLength": 39
         },
+        "farcaster": {
+          "type": "string",
+          "title": "farcaster",
+          "pattern": "^[a-z0-9][a-z0-9-]*$",
+          "maxLength": 16
+        },
         "email": {
           "type": "string",
           "title": "email",

--- a/src/schemas/space.json
+++ b/src/schemas/space.json
@@ -80,9 +80,7 @@
         },
         "farcaster": {
           "type": "string",
-          "title": "farcaster",
-          "pattern": "^[a-z0-9][a-z0-9-]*$",
-          "maxLength": 16
+          "title": "farcaster"
         },
         "email": {
           "type": "string",


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/565

Adds farcaster username to space profile

name validation from https://github.com/farcasterxyz/protocol/blob/main/docs/SPECIFICATION.md#5-fname-specifications : max 16 charaters, start by number or letter, and can only contain lowercase letter, number and hyphen