### PR TITLE
fix: use a dedicated key for brovider id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/networks.json
+++ b/src/networks.json
@@ -1972,12 +1972,13 @@
     "logo": "ipfs://QmNnGPr1CNvj12SSGzKARtUHv9FyEfE5nES73U4vBWQSJL"
   },
   "0x534e5f4d41494e": {
-    "key": "sn",
+    "key": "0x534e5f4d41494e",
     "name": "Starknet",
     "shortName": "Starknet",
     "chainId": "0x534e5f4d41494e",
     "network": "mainnet",
     "starknet": true,
+    "broviderId": "sn",
     "multicall": "0x05754af3760f3356da99aea5c3ec39ccac7783d925a19666ebbeca58ff0087f4",
     "explorer": {
       "url": "https://starkscan.co"
@@ -1987,12 +1988,13 @@
     "logo": "ipfs://bafkreihbjafyh7eud7r6e5743esaamifcttsvbspfwcrfoc5ykodjdi67m"
   },
   "0x534e5f5345504f4c4941": {
-    "key": "sn-sep",
-    "name": "Starknet Testnet",
+    "key": "0x534e5f5345504f4c4941",
+    "name": "Starknet Sepolia",
     "shortName": "testnet",
     "chainId": "0x534e5f5345504f4c4941",
     "network": "testnet",
     "starknet": true,
+    "broviderId": "sn-sep",
     "testnet": true,
     "multicall": "0x05754af3760f3356da99aea5c3ec39ccac7783d925a19666ebbeca58ff0087f4",
     "explorer": {

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -38,7 +38,7 @@ function getBroviderNetworkId(network: string | number): string {
   if (!config) {
     throw new Error(`Network '${network}' is not supported`);
   }
-  return config.broviderId || network;
+  return config.broviderId || String(network);
 }
 
 function getProviderType(network: string | number): ProviderType {

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -38,7 +38,7 @@ function getBroviderNetworkId(network: string | number): string {
   if (!config) {
     throw new Error(`Network '${network}' is not supported`);
   }
-  return String(config.key);
+  return config.broviderId || network;
 }
 
 function getProviderType(network: string | number): ProviderType {


### PR DESCRIPTION
Brovider is using a special string for starknet id (`sn`), which is not the chain id, like all the other networks.

We're currently using the `key` property to pass that for starknet, but it's not compatible with a lot of implementation, which is using `key` as chain ID.

This PR will add a new dedicated `broviderId` key, for networks having a custon brovider id, and fallback to the network id when missing. The `key` will be back to be the chain ID