### PR TITLE
feat: return owner of .sonic domains (#1168)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,14 +43,17 @@ const ENS_ABI = [
   'function text(bytes32 node, string calldata key) external view returns (string memory)',
   'function resolver(bytes32 node) view returns (address)' // ENS registry ABI
 ];
-const SONIC_ABI = [
+const UD_MAPPING = {
+  '146': {
+    tlds: ['.sonic'],
+    registryContract: '0xde1dadcf11a7447c3d093e97fdbd513f488ce3b4'
+  }
+};
+const UD_REGISTRY_ABI = [
   'function ownerOf(uint256 tokenId) external view returns (address address)'
 ];
-const SONIC_CONTRACT_ADDRESS = '0xde1dadcf11a7447c3d093e97fdbd513f488ce3b4';
 const ENS_CHAIN_IDS = ['1', '11155111'];
 const SHIBARIUM_CHAIN_IDS = ['109', '157'];
-const SONIC_CHAIN_IDS = ['146'];
-const SONIC_TLD = '.sonic';
 const SHIBARIUM_TLD = '.shib';
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 
@@ -701,23 +704,24 @@ export async function getShibariumNameOwner(
   return data.result;
 }
 
-export async function getSonicNameOwner(
+export async function getUDNameOwner(
   id: string,
   network: string
 ): Promise<string> {
-  if (!id.endsWith(SONIC_TLD)) {
+  const tlds = UD_MAPPING[network]?.tlds || [];
+  if (!tlds.some((tld: string) => id.endsWith(tld))) {
     return Promise.resolve(EMPTY_ADDRESS);
   }
 
   try {
     const hash = namehash(ensNormalize(id));
-    const tokenId = BigInt(hash).toString();
+    const tokenId = BigInt(hash);
     const provider = getProvider(network);
 
     return await call(
       provider,
-      SONIC_ABI,
-      [SONIC_CONTRACT_ADDRESS, 'ownerOf', [tokenId]],
+      UD_REGISTRY_ABI,
+      [UD_MAPPING[network].registryContract, 'ownerOf', [tokenId]],
       {
         blockTag: 'latest'
       }
@@ -736,8 +740,8 @@ export async function getSpaceController(
     return getEnsSpaceController(id, network, options);
   } else if (SHIBARIUM_CHAIN_IDS.includes(network)) {
     return getShibariumNameOwner(id, network);
-  } else if (SONIC_CHAIN_IDS.includes(network)) {
-    return getSonicNameOwner(id, network);
+  } else if (UD_MAPPING[String(network)]) {
+    return getUDNameOwner(id, network);
   }
 
   throw new Error(`Network not supported: ${network}`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,7 +50,7 @@ const UD_MAPPING = {
   }
 };
 const UD_REGISTRY_ABI = [
-  'function ownerOf(uint256 tokenId) external view returns (address address)'
+  'function ownerOf(uint256 tokenId) view returns (address owner)'
 ];
 const ENS_CHAIN_IDS = ['1', '11155111'];
 const SHIBARIUM_CHAIN_IDS = ['109', '157'];

--- a/test/e2e/utils.spec.js
+++ b/test/e2e/utils.spec.js
@@ -2,7 +2,7 @@ import { describe, test, expect } from 'vitest';
 import {
   getEnsOwner,
   getShibariumNameOwner,
-  getSonicNameOwner
+  getUDNameOwner
 } from '../../src/utils';
 
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
@@ -99,20 +99,20 @@ describe('utils', () => {
 
     describe('sonic resolver', () => {
       test('return an empty address for unrecognized extension', () => {
-        expect(getSonicNameOwner('invalid.domain', '146')).resolves.toBe(
+        expect(getUDNameOwner('invalid.domain', '146')).resolves.toBe(
           EMPTY_ADDRESS
         );
       });
 
       test('return an empty address for un-existing domain', () => {
-        expect(
-          getSonicNameOwner('snapshot-not-exist.sonic', '146')
-        ).resolves.toBe(EMPTY_ADDRESS);
+        expect(getUDNameOwner('snapshot-not-exist.sonic', '146')).resolves.toBe(
+          EMPTY_ADDRESS
+        );
       });
 
       test('return the name owner on sonic mainnet', () => {
-        expect(getSonicNameOwner('boorger.sonic', '146')).resolves.toBe(
-          '0x17Af7086649580ab880060c92F46fc931AB3588B'
+        expect(getUDNameOwner('boorger.sonic', '146')).resolves.toBe(
+          '0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6'
         );
       });
     });


### PR DESCRIPTION
Toward https://github.com/snapshot-labs/workflow/issues/598

This PR improves the .sonic domain name owner 

- now poll the registry for the owner, instead of the NFT contract (registry address not in the docs, obtained via direct contact with ud)
- function has been refactored to be future-proof, and ready to handle more chain/tld from unstoppable domains

Updated the test, since the `boorger.sonic` domain has now changed owner (EOA wallet, instead of UD custody wallet)