### PR TITLE
fix: fix NaN computation on ranked choice

### DIFF
--- a/src/voting/rankedChoice.ts
+++ b/src/voting/rankedChoice.ts
@@ -143,7 +143,7 @@ export default class RankedChoiceVoting {
       this.strategies.map((strategy, sI) => {
         return finalRound
           .filter((res) => Number(res[0]) === i + 1)
-          .reduce((a, b) => a + b[1][1][sI], 0);
+          .reduce((a, b) => a + b[1][1][sI] || 0, 0);
       })
     );
   }


### PR DESCRIPTION
In ranked choice, getScoresByStrategy, the array can sometime contain `NaN`, when the choice is not present in the final round (sum a number with undefined)

Those NaN value are then passed to sequencer, who will then save it as null, giving scores column with `null` values in the proposals table, on the hub database

```sql
SELECT id, scores_by_strategy
  FROM proposals
  WHERE scores_by_strategy LIKE '%null%';
```

This fix will fallback missing score to 0