### PR TITLE
fix: fix operator precedence

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.14.7",
+  "version": "0.14.8",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/voting/rankedChoice.ts
+++ b/src/voting/rankedChoice.ts
@@ -143,7 +143,7 @@ export default class RankedChoiceVoting {
       this.strategies.map((strategy, sI) => {
         return finalRound
           .filter((res) => Number(res[0]) === i + 1)
-          .reduce((a, b) => a + b[1][1][sI] || 0, 0);
+          .reduce((a, b) => a + (b[1][1][sI] || 0), 0);
       })
     );
   }


### PR DESCRIPTION
This PR fix an operator precedence issue, which was returning scores as 0 instead of the existing value, when summing with `undefined`