### PR TITLE
fix: update Ethereum Classic network config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.14.21",
+  "version": "0.14.22",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/networks.json
+++ b/src/networks.json
@@ -176,12 +176,12 @@
     "shortName": "Ethereum Classic",
     "chainId": 61,
     "network": "mainnet",
-    "multicall": "0x51be3a92C56ae7E207C5b5Fd87F7798Ce82C1AC2",
+    "multicall": "0xcA11bde05977b3631167028862bE2a173976CA11",
     "rpc": [
-      "https://www.ethercluster.com/etc"
+      "https://etc.rivet.link"
     ],
     "explorer": {
-      "url": "https://blockscout.com/etc/mainnet"
+      "url": "https://etc.blockscout.com"
     },
     "start": 13307544,
     "logo": "ipfs://QmVegc28DvA7LjKUFysab81c9BSuN4wQVDQkRXyAtuEBis"


### PR DESCRIPTION
- Update multicall to Multicall3 canonical address (0xcA11bde05977b3631167028862bE2a173976CA11)
- Update RPC endpoint (ethercluster.com is no longer operational)
- Update Blockscout explorer URL