### PR TITLE
chore: pin ajv to exact 8.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@ethersproject/providers": "^5.6.8",
     "@ethersproject/units": "^5.7.0",
     "@ethersproject/wallet": "^5.6.2",
-    "ajv": "^8.11.0",
+    "ajv": "8.11.0",
     "ajv-errors": "^3.0.0",
     "ajv-formats": "^2.1.1",
     "cross-fetch": "^3.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1267,6 +1267,16 @@ ajv-formats@^2.1.1:
   dependencies:
     ajv "^8.0.0"
 
+ajv@8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -1281,16 +1291,6 @@ ajv@^8.0.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.0.tgz#60cc45d9c46a477d80d92c48076d972c342e5720"
   integrity sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
-    uri-js "^4.2.2"
-
-ajv@^8.11.0:
-  version "8.11.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
-  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"


### PR DESCRIPTION
## Summary
- Tighten the `ajv` constraint from `^8.11.0` to an exact pin (`8.11.0`).
- No code changes — purely a `package.json` / `yarn.lock` adjustment.

## Why

`ajv-errors@3.0.0` (current latest) emits broken validator code when paired with `ajv@8.20.0`. Compiled validators end up with references like:

```js
{"str":"err76"}.keyword !== "errorMessage"
```

instead of the intended:

```js
err76.keyword !== "errorMessage"
```

…which throws `SyntaxError: Unexpected token ':'` the first time the validator runs. That blows up `snapshot.utils.validateSchema(...)` for any non-trivial schema (the space schema is the easy reproducer).

The bug only surfaces in downstream services using **bun**, because bun resolves `^8.11.0` fresh and lands on `8.20.0`. Yarn historically had `8.11.0` locked, so the bug never showed up there. ajv-errors has no newer release and there's no working ajv 8.21+ yet, so the only clean lever is to pin from this side.

`8.11.0` is the version snapshot.js has been deployed against in production for years, so this is a no-behavior-change pin rather than a downgrade.

## Why not handle this downstream?
[snapshot-sequencer#638](https://github.com/snapshot-labs/snapshot-sequencer/pull/638) currently ships an undocumented `"ajv": "8.11.0"` direct dependency on each consumer to force-hoist 8.11.0 to the root. Bun doesn't (yet) support nested `overrides` (oven-sh/bun#6608), so the workaround can't even be scoped. Pinning at the source avoids every downstream having to repeat this hack.

## Test plan
- [x] `yarn install` regenerates `yarn.lock` with `ajv@8.11.0` (no other resolutions change)
- [x] `yarn typecheck` passes
- [x] `yarn lint` passes
- [x] `yarn test:once` — same 335 passing / 2 pre-existing flaky e2e failures (sepolia ENS resolver, Starknet multicall) as `master`. No new failures.
- [ ] On release, bump `@snapshot-labs/snapshot.js` in `snapshot-sequencer#638` and drop its direct `ajv` dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)