### PR TITLE
feat: add MYRX-MAINNET network (chain ID 8472)

### DIFF
--- a/src/networks.json
+++ b/src/networks.json
@@ -2046,5 +2046,19 @@
     "rpc": [],
     "start": 7,
     "logo": "ipfs://bafkreihbjafyh7eud7r6e5743esaamifcttsvbspfwcrfoc5ykodjdi67m"
+  },
+  "8472": {
+    "key": "8472",
+    "name": "MYRX-MAINNET",
+    "chainId": 8472,
+    "network": "8472",
+    "multicall": "0xcA11bde05977b3631167028862bE2a173976CA11",
+    "rpc": [
+      "https://rpc.myrxwallet.io"
+    ],
+    "ws": [],
+    "explorer": "https://explorer.myrxwallet.io",
+    "start": 1,
+    "logo": "ipfs://QmPDMhjTgZuFwN44NsQkKHcPQuuQJCMHeruuLzoKbNQAxw"
   }
 }

--- a/src/networks.json
+++ b/src/networks.json
@@ -2050,15 +2050,15 @@
   "8472": {
     "key": "8472",
     "name": "MYRX-MAINNET",
+    "shortName": "MYRX",
     "chainId": 8472,
-    "network": "8472",
+    "network": "myrx-mainnet",
     "multicall": "0xcA11bde05977b3631167028862bE2a173976CA11",
     "rpc": [
       "https://rpc.myrxwallet.io"
     ],
-    "ws": [],
-    "explorer": "https://explorer.myrxwallet.io",
-    "start": 1,
-    "logo": "ipfs://QmPDMhjTgZuFwN44NsQkKHcPQuuQJCMHeruuLzoKbNQAxw"
+    "explorer": {
+      "url": "https://explorer.myrxwallet.io"
+    }
   }
 }


### PR DESCRIPTION
## MYRX-MAINNET -- Chain ID 8472

Sovereign EVM blockchain operated by MyRxWallet North America Corporation.

### Network parameters
- **Chain ID:** 8472
- **RPC:** https://rpc.myrxwallet.io
- **Explorer:** https://explorer.myrxwallet.io (EIP-3091)
- **Multicall3:** 0xcA11bde05977b3631167028862bE2a173976CA11 (canonical address, deployed at genesis)
- **Logo:** ipfs://QmPDMhjTgZuFwN44NsQkKHcPQuuQJCMHeruuLzoKbNQAxw

### Verification
```
cast chain-id --rpc-url https://rpc.myrxwallet.io
# Returns: 8472

cast call 0xcA11bde05977b3631167028862bE2a173976CA11 'getBlockNumber()(uint256)' --rpc-url https://rpc.myrxwallet.io
# Returns current block
```

### Use case
Healthcare data and payments infrastructure. HIPAA-aligned data flows, provider settlement, patient-controlled data licensing.

### Contact
developer@myrxwallet.io | https://myrxwallet.io