### PR TITLE
fix(multicall): decode legacy bytes32 string returns

### DIFF
--- a/src/multicall/evm.ts
+++ b/src/multicall/evm.ts
@@ -1,4 +1,5 @@
 import {
+  defaultAbiCoder,
   Fragment,
   FunctionFragment,
   Interface,
@@ -7,10 +8,35 @@ import {
 import { Signer } from '@ethersproject/abstract-signer';
 import { Contract } from '@ethersproject/contracts';
 import { Provider } from '@ethersproject/providers';
+import { parseBytes32String } from '@ethersproject/strings';
 
 const multicallAbi = [
   'function aggregate(tuple(address target, bytes callData)[] calls) view returns (uint256 blockNumber, bytes[] returnData)'
 ];
+
+// Legacy tokens (MKR/SAI/AVT-era) declare `string` in the ABI but return
+// `bytes32`. Fall back to bytes32 decoding so one such call doesn't fail
+// the whole batch.
+function decodeResult(
+  itf: Interface,
+  fn: FunctionFragment | string,
+  data: string
+): any {
+  try {
+    return itf.decodeFunctionResult(fn, data);
+  } catch (e) {
+    const outputs = (typeof fn === 'string' ? itf.getFunction(fn) : fn).outputs;
+    if (!outputs?.some((o) => o.type === 'string')) throw e;
+    const altTypes = outputs.map((o) =>
+      o.type === 'string' ? 'bytes32' : o.type
+    );
+    return defaultAbiCoder
+      .decode(altTypes, data)
+      .map((v, i) =>
+        outputs[i].type === 'string' ? parseBytes32String(v) : v
+      );
+  }
+}
 
 export default async function multicall(
   address: string,
@@ -39,9 +65,7 @@ export default async function multicall(
     });
     let results: any[] = await Promise.all(promises);
     results = results.reduce((prev: any, [, res]: any) => prev.concat(res), []);
-    return results.map((call, i) =>
-      itf.decodeFunctionResult(calls[i][1], call)
-    );
+    return results.map((call, i) => decodeResult(itf, calls[i][1], call));
   } catch (e: any) {
     return Promise.reject(e);
   }


### PR DESCRIPTION
## Summary
- Legacy tokens (MKR, SAI, AVT-era) declare `string` for `name()`/`symbol()` in their ABI but actually return `bytes32`. With the standard ERC20 ABI, `decodeFunctionResult` throws and fails the **entire** multicall batch — even if only one of N tokens is affected.
- Adds a narrow decode-side fallback: when strict decode fails **and** the function declares a `string` output, retry by decoding those outputs as `bytes32` and converting via `parseBytes32String`.
- Encode side is untouched (intentionally — silent `string → bytes32` padding would be a footgun for any strategy using `bytes32` keys/IDs).

## Why this matters for Snapshot
Strategies that touch a long list of tokens (e.g. multi-token balance aggregators, indexers) currently break if any single token in the list is a legacy `bytes32`-symbol token. With this change, one bad token in a 200-token batch no longer poisons the whole batch.

## Behavior matrix
| Case | Before | After |
|---|---|---|
| Strict decode succeeds | works | identical |
| Decode fails, function has no `string` output | throws original error | throws original error |
| Decode fails, function has `string` output, bytes32-fallback works (MKR/AVT) | **throws, batch fails** | returns decoded string |

## Test plan
- [x] Manually verified against UNI, ENS, AAVE (standard) + AVT, MKR (legacy `bytes32` symbol) — all five fetch correctly in one batch
- [ ] CI typecheck + lint
- [ ] Reviewer sanity-check on strategies that read token metadata in batches

cc @ChaituVR

🤖 Generated with [Claude Code](https://claude.com/claude-code)