### PR TITLE
chore: add dependabot config for @snapshot-labs/* deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "@snapshot-labs/*"
+    ignore:
+      - dependency-name: "@snapshot-labs/snapshot.js"
+    groups:
+      snapshot:
+        patterns:
+          - "@snapshot-labs/*"


### PR DESCRIPTION
Adds a dependabot config (daily npm, scoped to \`@snapshot-labs/*\`, grouped into one PR per cycle) — this repo had none. Matches the config across the other snapshot-labs repos.

cc @ChaituVR