### PR TITLE
feat: ENSv2-ready name resolution via Universal Resolver and viem

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
           registry-url: https://registry.npmjs.org/
       - run: yarn install --frozen-lockfile
       - run: npm publish

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - name: Yarn install
         run: yarn install --frozen-lockfile
       - name: Typecheck

--- a/.github/workflows/update-minor-version.yml
+++ b/.github/workflows/update-minor-version.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-node@v1
 
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - name: Update minor
         run: |
           npm --no-git-tag-version version patch

--- a/.github/workflows/update-network.yml
+++ b/.github/workflows/update-network.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v1
         with:
-          node-version: '16.10.0'
+          node-version: '18.x'
       - name: Add new network
         run: |
           yarn install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "cross-fetch": "^3.1.6",
     "json-to-graphql-query": "^2.2.4",
     "lodash.set": "^4.3.2",
-    "starknet": "^6.11.0"
+    "starknet": "^6.11.0",
+    "viem": "^2.55.10"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^18.1.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "browser": "dist/snapshot.min.js",
   "types": "dist/src/index.d.ts",
   "dependencies": {
-    "@ensdomains/eth-ens-namehash": "^2.0.15",
     "@ethersproject/abi": "^5.6.4",
     "@ethersproject/address": "^5.6.1",
     "@ethersproject/bignumber": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "prepublishOnly": "yarn build"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "files": [
     "dist",

--- a/rollup.cjs.config.js
+++ b/rollup.cjs.config.js
@@ -4,7 +4,10 @@ import { string } from 'rollup-plugin-string';
 import pkg from './package.json';
 
 const input = 'src/index.ts';
-const external = [...Object.keys(pkg.dependencies || {})];
+const dependencies = [...Object.keys(pkg.dependencies || {})];
+// match subpath imports too (e.g. viem/ens)
+const external = (id) =>
+  dependencies.some((dep) => id === dep || id.startsWith(`${dep}/`));
 
 export default [
   {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,10 @@ import pkg from './package.json';
 
 const name = 'snapshot';
 const input = 'src/index.ts';
-const external = [...Object.keys(pkg.dependencies || {})];
+const dependencies = [...Object.keys(pkg.dependencies || {})];
+// match subpath imports too (e.g. viem/ens)
+const external = (id) =>
+  dependencies.some((dep) => id === dep || id.startsWith(`${dep}/`));
 
 export default [
   {
@@ -22,6 +25,9 @@ export default [
         name,
         file: pkg.browser,
         format: 'umd',
+        // viem uses dynamic import() internally (CCIP-Read module), which
+        // rollup would otherwise code-split — unsupported in UMD bundles
+        inlineDynamicImports: true,
         intro:
           'var global = typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {}'
       }

--- a/src/networks.json
+++ b/src/networks.json
@@ -10,6 +10,7 @@
       "0x4976fb03C32e5B8cfe2b6cCB31c09Ba78EBaBa41",
       "0xF29100983E058B709F3D539b0c765937B804AC15"
     ],
+    "ensUniversalResolver": "0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe",
     "ensNameWrapper": "0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401",
     "ensSubgraph": "https://subgrapher.snapshot.org/subgraph/arbitrum/5XqPmWe6gjyrJtFn9cLy237i4cWw2j9HcUJEXsP5qGtH",
     "rpc": [
@@ -1893,6 +1894,7 @@
     "ensResolvers": [
       "0x8FADE66B79cC9f707aB26799354482EB93a5B7dD"
     ],
+    "ensUniversalResolver": "0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe",
     "ensNameWrapper": "0x0635513f179D50A207757E05759CbD106d7dFcE8",
     "ensSubgraph": "https://subgrapher.snapshot.org/subgraph/arbitrum/CA5t8ep58QKXBdLrjJHaREETHpCsy63kro9Eem6zBQAD",
     "explorer": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,8 @@ import { Contract } from '@ethersproject/contracts';
 import { getAddress, isAddress } from '@ethersproject/address';
 import { parseUnits } from '@ethersproject/units';
 import { namehash, ensNormalize } from '@ethersproject/hash';
+import { Interface } from '@ethersproject/abi';
+import { hexlify, concat } from '@ethersproject/bytes';
 import { jsonToGraphQLQuery } from 'json-to-graphql-query';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
@@ -39,10 +41,23 @@ const MUTED_ERRORS = [
   'UNSUPPORTED_OPERATION'
 ];
 const ENS_REGISTRY = '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e';
-const ENS_ABI = [
-  'function text(bytes32 node, string calldata key) external view returns (string memory)',
-  'function resolver(bytes32 node) view returns (address)' // ENS registry ABI
+const UNIVERSAL_RESOLVER_ADDRESS =
+  '0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe';
+const UNIVERSAL_RESOLVER_ABI = [
+  'error ResolverNotFound(bytes name)',
+  'error ResolverNotContract(bytes name, address resolver)',
+  'error UnsupportedResolverProfile(bytes4 selector)',
+  'error ResolverError(bytes errorData)',
+  'error ReverseAddressMismatch(string primary, bytes primaryAddress)',
+  'error HttpError(uint16 status, string message)',
+  'function resolve(bytes name, bytes data) view returns (bytes result, address resolver)',
+  'function findOwner(bytes name) view returns (address owner)'
 ];
+const RESOLVER_ABI = [
+  'function text(bytes32 node, string key) view returns (string)',
+  'function addr(bytes32 node) view returns (address)'
+];
+const resolverInterface = new Interface(RESOLVER_ABI);
 const UD_MAPPING = {
   '146': {
     tlds: ['.sonic'],
@@ -225,6 +240,43 @@ function getDomainType(domain: string): DomainType {
   else if (tokens.length > 2) return 'subdomain';
   else if (isEns) return 'ens';
   else throw new Error('Invalid domain');
+}
+
+function dnsEncodeName(name: string): string {
+  const normalized = ensNormalize(name);
+  const labels = normalized.split('.');
+  const encodedLabels = labels.map((label) => {
+    if (!label.length || label.length > 63) {
+      throw new Error(`Invalid ENS label: ${label}`);
+    }
+    const labelBytes = new TextEncoder().encode(label);
+    return concat([Uint8Array.from([labelBytes.length]), labelBytes]);
+  });
+  return hexlify(concat([...encodedLabels, new Uint8Array([0])]));
+}
+
+function getUniversalResolverAddress(network: string, options: any = {}) {
+  return (
+    options.ensUniversalResolver ||
+    networks[network]?.ensUniversalResolver ||
+    UNIVERSAL_RESOLVER_ADDRESS
+  );
+}
+
+async function unwrapNameWrapperOwner(
+  owner: string,
+  ensHash: string,
+  ensNameWrapper: string,
+  provider: any
+): Promise<string> {
+  if (owner !== ensNameWrapper) return owner;
+
+  const ensNameWrapperContract = new Contract(
+    ensNameWrapper,
+    ['function ownerOf(uint256) view returns (address)'],
+    provider
+  );
+  return ensNameWrapperContract.ownerOf(ensHash);
 }
 
 // see https://docs.ens.domains/registry/dns#gasless-import
@@ -615,42 +667,38 @@ export async function getEnsTextRecord(
   network = '1',
   options: any = {}
 ) {
-  const {
-    ensResolvers = networks[network]?.ensResolvers ||
-      networks['1'].ensResolvers,
-    broviderUrl,
-    ...multicallOptions
-  } = options;
+  const { broviderUrl } = options;
 
   let ensHash: string;
+  let dnsEncodedName: string;
 
   try {
-    ensHash = namehash(ensNormalize(ens));
+    const normalized = ensNormalize(ens);
+    ensHash = namehash(normalized);
+    dnsEncodedName = dnsEncodeName(normalized);
   } catch (e: any) {
     return null;
   }
 
   const provider = getProvider(network, { broviderUrl });
+  const universalResolver = new Contract(
+    getUniversalResolverAddress(network, options),
+    UNIVERSAL_RESOLVER_ABI,
+    provider
+  );
 
-  const calls = [
-    [ENS_REGISTRY, 'resolver', [ensHash]], // Query for resolver from registry
-    ...ensResolvers.map((address: string) => [
-      address,
-      'text',
-      [ensHash, record]
-    ]) // Query for text record from each resolver
-  ];
-
-  const [[resolverAddress], ...textRecords] = (await multicall(
-    network,
-    provider,
-    ENS_ABI,
-    calls,
-    multicallOptions
-  )) as string[][];
-
-  const resolverIndex = ensResolvers.indexOf(resolverAddress);
-  return resolverIndex !== -1 ? textRecords[resolverIndex]?.[0] : null;
+  try {
+    const data = resolverInterface.encodeFunctionData('text', [
+      ensHash,
+      record
+    ]);
+    const [result] = await universalResolver.resolve(dnsEncodedName, data, {
+      ccipReadEnabled: true
+    });
+    return resolverInterface.decodeFunctionResult('text', result)[0];
+  } catch (e: any) {
+    return null;
+  }
 }
 
 export async function getSpaceUri(
@@ -671,7 +719,7 @@ export async function getEnsOwner(
   network = '1',
   options: any = {}
 ): Promise<string> {
-  if (!networks[network]?.ensResolvers?.length) {
+  if (!networks[network]?.ensUniversalResolver) {
     throw new Error('Network not supported');
   }
 
@@ -684,24 +732,47 @@ export async function getEnsOwner(
   );
 
   let ensHash: string;
+  let dnsEncodedName: string;
 
   try {
-    ensHash = namehash(ensNormalize(ens));
+    const normalized = ensNormalize(ens);
+    ensHash = namehash(normalized);
+    dnsEncodedName = dnsEncodeName(normalized);
   } catch (e: any) {
     return EMPTY_ADDRESS;
   }
 
   const ensNameWrapper =
     options.ensNameWrapper || networks[network].ensNameWrapper;
-  let owner = await ensRegistry.owner(ensHash);
-  // If owner is the ENSNameWrapper contract, resolve the owner of the name
-  if (owner === ensNameWrapper) {
-    const ensNameWrapperContract = new Contract(
+  const universalResolver = new Contract(
+    getUniversalResolverAddress(network, options),
+    UNIVERSAL_RESOLVER_ABI,
+    provider
+  );
+
+  let owner = EMPTY_ADDRESS;
+
+  // Prefer Universal Resolver findOwner (ENSv2); fall back when unavailable
+  try {
+    owner = await universalResolver.findOwner(dnsEncodedName);
+    owner = await unwrapNameWrapperOwner(
+      owner,
+      ensHash,
       ensNameWrapper,
-      ['function ownerOf(uint256) view returns (address)'],
       provider
     );
-    owner = await ensNameWrapperContract.ownerOf(ensHash);
+  } catch (e: any) {
+    owner = EMPTY_ADDRESS;
+  }
+
+  if (!owner || owner === EMPTY_ADDRESS) {
+    owner = await ensRegistry.owner(ensHash);
+    owner = await unwrapNameWrapperOwner(
+      owner,
+      ensHash,
+      ensNameWrapper,
+      provider
+    );
   }
 
   if (owner === EMPTY_ADDRESS && domainType === 'other-tld') {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -239,13 +239,18 @@ function dnsEncodeName(name: string): Hex {
   const normalized = normalize(name);
   const labels = normalized.split('.');
   const encodedLabels = labels.map((label) => {
-    if (!label.length || label.length > 63) {
+    // DNS limits are in bytes, not characters
+    const labelBytes = stringToBytes(label);
+    if (!labelBytes.length || labelBytes.length > 63) {
       throw new Error(`Invalid ENS label: ${label}`);
     }
-    const labelBytes = stringToBytes(label);
     return concat([Uint8Array.from([labelBytes.length]), labelBytes]);
   });
-  return toHex(concat([...encodedLabels, new Uint8Array([0])]));
+  const encoded = concat([...encodedLabels, new Uint8Array([0])]);
+  if (encoded.length > 255) {
+    throw new Error(`DNS-encoded name exceeds 255 bytes: ${name}`);
+  }
+  return toHex(encoded);
 }
 
 function getUniversalResolverAddress(
@@ -265,7 +270,8 @@ async function unwrapNameWrapperOwner(
   ensNameWrapper: string,
   client: PublicClient
 ): Promise<string> {
-  if (owner !== ensNameWrapper) return owner;
+  if (!ensNameWrapper || owner.toLowerCase() !== ensNameWrapper.toLowerCase())
+    return owner;
 
   return await client.readContract({
     address: ensNameWrapper as Address,
@@ -663,8 +669,6 @@ export async function getEnsTextRecord(
   network = '1',
   options: any = {}
 ) {
-  const { broviderUrl } = options;
-
   let normalized: string;
 
   try {
@@ -674,7 +678,7 @@ export async function getEnsTextRecord(
     return null;
   }
 
-  const client = getViemClient(network, { broviderUrl });
+  const client = getViemClient(network, options);
 
   try {
     return await client.getEnsText({
@@ -779,15 +783,14 @@ export async function getEnsOwner(
   }
 
   if (owner === EMPTY_ADDRESS && domainType === 'subdomain') {
-    try {
-      owner =
-        (await client.getEnsAddress({
-          name: normalized,
-          universalResolverAddress
-        })) || EMPTY_ADDRESS;
-    } catch (e: any) {
-      owner = EMPTY_ADDRESS;
-    }
+    // viem returns null for unresolvable names (non-strict mode), so only
+    // genuine transport/RPC failures throw — let those propagate instead of
+    // silently reporting the name as unowned
+    owner =
+      (await client.getEnsAddress({
+        name: normalized,
+        universalResolverAddress
+      })) || EMPTY_ADDRESS;
   }
 
   return owner || EMPTY_ADDRESS;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,15 +2,15 @@ import crossFetch from 'cross-fetch';
 import { Contract } from '@ethersproject/contracts';
 import { getAddress, isAddress } from '@ethersproject/address';
 import { parseUnits } from '@ethersproject/units';
-import { namehash, ensNormalize } from '@ethersproject/hash';
-import { Interface } from '@ethersproject/abi';
-import { hexlify, concat } from '@ethersproject/bytes';
+import { parseAbi, concat, stringToBytes, toHex } from 'viem';
+import { namehash, normalize } from 'viem/ens';
+import type { Address, Hex, PublicClient } from 'viem';
 import { jsonToGraphQLQuery } from 'json-to-graphql-query';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import addErrors from 'ajv-errors';
 import { getSnapshots } from './utils/blockfinder';
-import getProvider from './utils/provider';
+import getProvider, { getViemClient } from './utils/provider';
 import { signMessage, getBlockNumber } from './utils/web3';
 import { getHash, verify } from './verify';
 import gateways from './gateways.json';
@@ -33,17 +33,9 @@ interface Strategy {
 
 type DomainType = 'ens' | 'tld' | 'other-tld' | 'subdomain';
 
-const MUTED_ERRORS = [
-  // mute error from coinbase, when the subdomain is not found
-  // most other resolvers just return an empty address
-  'response not found during CCIP fetch',
-  // mute error from missing offchain resolver (mostly for sepolia)
-  'UNSUPPORTED_OPERATION'
-];
 const ENS_REGISTRY = '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e';
-const UNIVERSAL_RESOLVER_ADDRESS =
-  '0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe';
-const UNIVERSAL_RESOLVER_ABI = [
+const UNIVERSAL_RESOLVER_ADDRESS = '0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe';
+const UNIVERSAL_RESOLVER_ABI = parseAbi([
   'error ResolverNotFound(bytes name)',
   'error ResolverNotContract(bytes name, address resolver)',
   'error UnsupportedResolverProfile(bytes4 selector)',
@@ -52,12 +44,13 @@ const UNIVERSAL_RESOLVER_ABI = [
   'error HttpError(uint16 status, string message)',
   'function resolve(bytes name, bytes data) view returns (bytes result, address resolver)',
   'function findOwner(bytes name) view returns (address owner)'
-];
-const RESOLVER_ABI = [
-  'function text(bytes32 node, string key) view returns (string)',
-  'function addr(bytes32 node) view returns (address)'
-];
-const resolverInterface = new Interface(RESOLVER_ABI);
+]);
+const ENS_REGISTRY_ABI = parseAbi([
+  'function owner(bytes32 node) view returns (address)'
+]);
+const NAME_WRAPPER_ABI = parseAbi([
+  'function ownerOf(uint256 id) view returns (address)'
+]);
 const UD_MAPPING = {
   '146': {
     tlds: ['.sonic'],
@@ -242,20 +235,23 @@ function getDomainType(domain: string): DomainType {
   else throw new Error('Invalid domain');
 }
 
-function dnsEncodeName(name: string): string {
-  const normalized = ensNormalize(name);
+function dnsEncodeName(name: string): Hex {
+  const normalized = normalize(name);
   const labels = normalized.split('.');
   const encodedLabels = labels.map((label) => {
     if (!label.length || label.length > 63) {
       throw new Error(`Invalid ENS label: ${label}`);
     }
-    const labelBytes = new TextEncoder().encode(label);
+    const labelBytes = stringToBytes(label);
     return concat([Uint8Array.from([labelBytes.length]), labelBytes]);
   });
-  return hexlify(concat([...encodedLabels, new Uint8Array([0])]));
+  return toHex(concat([...encodedLabels, new Uint8Array([0])]));
 }
 
-function getUniversalResolverAddress(network: string, options: any = {}) {
+function getUniversalResolverAddress(
+  network: string,
+  options: any = {}
+): Address {
   return (
     options.ensUniversalResolver ||
     networks[network]?.ensUniversalResolver ||
@@ -265,18 +261,18 @@ function getUniversalResolverAddress(network: string, options: any = {}) {
 
 async function unwrapNameWrapperOwner(
   owner: string,
-  ensHash: string,
+  ensHash: Hex,
   ensNameWrapper: string,
-  provider: any
+  client: PublicClient
 ): Promise<string> {
   if (owner !== ensNameWrapper) return owner;
 
-  const ensNameWrapperContract = new Contract(
-    ensNameWrapper,
-    ['function ownerOf(uint256) view returns (address)'],
-    provider
-  );
-  return ensNameWrapperContract.ownerOf(ensHash);
+  return await client.readContract({
+    address: ensNameWrapper as Address,
+    abi: NAME_WRAPPER_ABI,
+    functionName: 'ownerOf',
+    args: [BigInt(ensHash)]
+  });
 }
 
 // see https://docs.ens.domains/registry/dns#gasless-import
@@ -669,33 +665,23 @@ export async function getEnsTextRecord(
 ) {
   const { broviderUrl } = options;
 
-  let ensHash: string;
-  let dnsEncodedName: string;
+  let normalized: string;
 
   try {
-    const normalized = ensNormalize(ens);
-    ensHash = namehash(normalized);
-    dnsEncodedName = dnsEncodeName(normalized);
+    normalized = normalize(ens);
+    dnsEncodeName(normalized);
   } catch (e: any) {
     return null;
   }
 
-  const provider = getProvider(network, { broviderUrl });
-  const universalResolver = new Contract(
-    getUniversalResolverAddress(network, options),
-    UNIVERSAL_RESOLVER_ABI,
-    provider
-  );
+  const client = getViemClient(network, { broviderUrl });
 
   try {
-    const data = resolverInterface.encodeFunctionData('text', [
-      ensHash,
-      record
-    ]);
-    const [result] = await universalResolver.resolve(dnsEncodedName, data, {
-      ccipReadEnabled: true
+    return await client.getEnsText({
+      name: normalized,
+      key: record,
+      universalResolverAddress: getUniversalResolverAddress(network, options)
     });
-    return resolverInterface.decodeFunctionResult('text', result)[0];
   } catch (e: any) {
     return null;
   }
@@ -724,18 +710,14 @@ export async function getEnsOwner(
   }
 
   const domainType = getDomainType(ens);
-  const provider = getProvider(network, options);
-  const ensRegistry = new Contract(
-    ENS_REGISTRY,
-    ['function owner(bytes32) view returns (address)'],
-    provider
-  );
+  const client = getViemClient(network, options);
 
-  let ensHash: string;
-  let dnsEncodedName: string;
+  let normalized: string;
+  let ensHash: Hex;
+  let dnsEncodedName: Hex;
 
   try {
-    const normalized = ensNormalize(ens);
+    normalized = normalize(ens);
     ensHash = namehash(normalized);
     dnsEncodedName = dnsEncodeName(normalized);
   } catch (e: any) {
@@ -744,39 +726,51 @@ export async function getEnsOwner(
 
   const ensNameWrapper =
     options.ensNameWrapper || networks[network].ensNameWrapper;
-  const universalResolver = new Contract(
-    getUniversalResolverAddress(network, options),
-    UNIVERSAL_RESOLVER_ABI,
-    provider
+  const universalResolverAddress = getUniversalResolverAddress(
+    network,
+    options
   );
 
-  let owner = EMPTY_ADDRESS;
+  let owner: string = EMPTY_ADDRESS;
 
   // Prefer Universal Resolver findOwner (ENSv2); fall back when unavailable
   try {
-    owner = await universalResolver.findOwner(dnsEncodedName);
+    owner = await client.readContract({
+      address: universalResolverAddress,
+      abi: UNIVERSAL_RESOLVER_ABI,
+      functionName: 'findOwner',
+      args: [dnsEncodedName]
+    });
     owner = await unwrapNameWrapperOwner(
       owner,
       ensHash,
       ensNameWrapper,
-      provider
+      client
     );
   } catch (e: any) {
     owner = EMPTY_ADDRESS;
   }
 
   if (!owner || owner === EMPTY_ADDRESS) {
-    owner = await ensRegistry.owner(ensHash);
+    owner = await client.readContract({
+      address: ENS_REGISTRY,
+      abi: ENS_REGISTRY_ABI,
+      functionName: 'owner',
+      args: [ensHash]
+    });
     owner = await unwrapNameWrapperOwner(
       owner,
       ensHash,
       ensNameWrapper,
-      provider
+      client
     );
   }
 
   if (owner === EMPTY_ADDRESS && domainType === 'other-tld') {
-    const resolvedAddress = await provider.resolveName(ens);
+    const resolvedAddress = await client.getEnsAddress({
+      name: normalized,
+      universalResolverAddress
+    });
 
     // Filter out domains with valid TXT records, but not imported
     if (resolvedAddress) {
@@ -786,11 +780,12 @@ export async function getEnsOwner(
 
   if (owner === EMPTY_ADDRESS && domainType === 'subdomain') {
     try {
-      owner = await provider.resolveName(ens);
+      owner =
+        (await client.getEnsAddress({
+          name: normalized,
+          universalResolverAddress
+        })) || EMPTY_ADDRESS;
     } catch (e: any) {
-      if (MUTED_ERRORS.every((error) => !e.message.includes(error))) {
-        throw e;
-      }
       owner = EMPTY_ADDRESS;
     }
   }
@@ -849,7 +844,7 @@ export async function getUDNameOwner(
   }
 
   try {
-    const hash = namehash(ensNormalize(id));
+    const hash = namehash(normalize(id));
     const tokenId = BigInt(hash);
     const provider = getProvider(network);
 

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -1,5 +1,6 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { RpcProvider } from 'starknet';
+import { createPublicClient, http, PublicClient } from 'viem';
 import networks from '../networks.json';
 
 export interface ProviderOptions {
@@ -71,6 +72,31 @@ export default function getProvider(
 
   providerMemo.set(memoKey, provider);
   return provider;
+}
+
+const viemClientMemo = new Map<string, PublicClient>();
+
+export function getViemClient(
+  network: string | number,
+  options: ProviderOptions = {}
+): PublicClient {
+  const networkId = getBroviderNetworkId(network);
+  const normalizedOptions = normalizeOptions(options);
+  const memoKey = createMemoKey(networkId, normalizedOptions);
+
+  const memoized = viemClientMemo.get(memoKey);
+  if (memoized) {
+    return memoized;
+  }
+
+  const client = createPublicClient({
+    transport: http(`${normalizedOptions.broviderUrl}/${networkId}`, {
+      timeout: normalizedOptions.timeout
+    })
+  });
+
+  viemClientMemo.set(memoKey, client);
+  return client;
 }
 
 function getEvmProvider(

--- a/test/e2e/utils.spec.js
+++ b/test/e2e/utils.spec.js
@@ -5,10 +5,26 @@ import {
   getUDNameOwner,
   getSpaceController
 } from '../../src/utils';
+import { getViemClient } from '../../src/utils/provider';
+import networks from '../../src/networks.json';
 
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 describe('utils', () => {
+  // See https://docs.ens.domains/web/ensv2-readiness/
+  // 0x1111...1111 would mean resolution bypasses the Universal Resolver
+  describe('ENSv2 readiness', () => {
+    test('resolve names through the Universal Resolver', async () => {
+      const client = getViemClient('1');
+      await expect(
+        client.getEnsAddress({
+          name: 'ur.integration-tests.eth',
+          universalResolverAddress: networks['1'].ensUniversalResolver
+        })
+      ).resolves.toBe('0x2222222222222222222222222222222222222222');
+    });
+  });
+
   describe('getSpaceController', () => {
     test('return the controller address for mainnet', async () => {
       await expect(getSpaceController('psydao.eth', '1')).resolves.toBe(

--- a/test/e2e/utils/blockfinder.spec.ts
+++ b/test/e2e/utils/blockfinder.spec.ts
@@ -4,29 +4,21 @@ import getProvider from '../../../src/utils/provider';
 
 describe('Test block finder', () => {
   const provider = getProvider('1');
-  test(
-    'getSnapshots should work without errors and return object',
-    async () => {
-      expect(
-        await getSnapshots('1', 17789783, provider, ['11155111', '137'])
-      ).toMatchObject({
-        '1': 17789783,
-        '137': 45609596,
-        '11155111': 3979201
-      });
-    },
-    30000
-  );
-  test(
-    'getSnapshots should return all latest if snapshot is latest',
-    async () => {
-      expect(
-        await getSnapshots('1', 'latest', provider, ['11155111', '137'])
-      ).toMatchObject({
-        '137': 'latest',
-        '11155111': 'latest'
-      });
-    },
-    30000
-  );
+  test('getSnapshots should work without errors and return object', async () => {
+    expect(
+      await getSnapshots('1', 17789783, provider, ['11155111', '137'])
+    ).toMatchObject({
+      '1': 17789783,
+      '137': 45609596,
+      '11155111': 3979201
+    });
+  }, 30000);
+  test('getSnapshots should return all latest if snapshot is latest', async () => {
+    expect(
+      await getSnapshots('1', 'latest', provider, ['11155111', '137'])
+    ).toMatchObject({
+      '137': 'latest',
+      '11155111': 'latest'
+    });
+  }, 30000);
 });

--- a/test/e2e/utils/blockfinder.spec.ts
+++ b/test/e2e/utils/blockfinder.spec.ts
@@ -4,21 +4,29 @@ import getProvider from '../../../src/utils/provider';
 
 describe('Test block finder', () => {
   const provider = getProvider('1');
-  test('getSnapshots should work without errors and return object', async () => {
-    expect(
-      await getSnapshots('1', 17789783, provider, ['11155111', '137'])
-    ).toMatchObject({
-      '1': 17789783,
-      '137': 45609596,
-      '11155111': 3979201
-    });
-  });
-  test('getSnapshots should return all latest if snapshot is latest', async () => {
-    expect(
-      await getSnapshots('1', 'latest', provider, ['11155111', '137'])
-    ).toMatchObject({
-      '137': 'latest',
-      '11155111': 'latest'
-    });
-  });
+  test(
+    'getSnapshots should work without errors and return object',
+    async () => {
+      expect(
+        await getSnapshots('1', 17789783, provider, ['11155111', '137'])
+      ).toMatchObject({
+        '1': 17789783,
+        '137': 45609596,
+        '11155111': 3979201
+      });
+    },
+    30000
+  );
+  test(
+    'getSnapshots should return all latest if snapshot is latest',
+    async () => {
+      expect(
+        await getSnapshots('1', 'latest', provider, ['11155111', '137'])
+      ).toMatchObject({
+        '137': 'latest',
+        '11155111': 'latest'
+      });
+    },
+    30000
+  );
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -71,11 +71,6 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@ensdomains/eth-ens-namehash@^2.0.15":
-  version "2.0.15"
-  resolved "https://registry.yarnpkg.com/@ensdomains/eth-ens-namehash/-/eth-ens-namehash-2.0.15.tgz#5e5f2f24ba802aff8bc19edd822c9a11200cdf4a"
-  integrity sha512-JRDFP6+Hczb1E0/HhIg0PONgBYasfGfDheujmfxaZaAv/NAH4jE6Kf48WbqfRZdxt4IZI3jl3Ri7sZ1nP09lgw==
-
 "@esbuild/android-arm64@0.17.19":
   version "0.17.19"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz#bafb75234a5d3d1b690e7c2956a599345e84a2fd"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@adraffy/ens-normalize@^1.11.0":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz#6c2d657d4b2dfb37f8ea811dcb3e60843d4ac24a"
+  integrity sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==
+
 "@ampproject/remapping@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.1.tgz#99e8e11851128b8702cd57c33684f1d0f260b630"
@@ -755,6 +760,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@noble/ciphers@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@noble/ciphers/-/ciphers-1.3.0.tgz#f64b8ff886c240e644e5573c097f86e5b43676dc"
+  integrity sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==
+
 "@noble/curves@1.7.0", "@noble/curves@~1.7.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.7.0.tgz#0512360622439256df892f21d25b388f52505e45"
@@ -762,10 +772,29 @@
   dependencies:
     "@noble/hashes" "1.6.0"
 
+"@noble/curves@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.1.tgz#9654a0bc6c13420ae252ddcf975eaf0f58f0a35c"
+  integrity sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==
+  dependencies:
+    "@noble/hashes" "1.8.0"
+
+"@noble/curves@~1.9.0":
+  version "1.9.7"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.7.tgz#79d04b4758a43e4bca2cbdc62e7771352fa6b951"
+  integrity sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==
+  dependencies:
+    "@noble/hashes" "1.8.0"
+
 "@noble/hashes@1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.6.0.tgz#d4bfb516ad6e7b5111c216a5cc7075f4cf19e6c5"
   integrity sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==
+
+"@noble/hashes@1.8.0", "@noble/hashes@^1.8.0", "@noble/hashes@~1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
+  integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
 
 "@noble/hashes@~1.6.0":
   version "1.6.1"
@@ -908,6 +937,28 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.1.tgz#dd0b2a533063ca612c17aa9ad26424a2ff5aa865"
   integrity sha512-DGmGtC8Tt63J5GfHgfl5CuAXh96VF/LD8K9Hr/Gv0J2lAoRGlPOMpqMpMbCTOoOJMZCk2Xt+DskdDyn6dEFdzQ==
+
+"@scure/base@~1.2.5":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.6.tgz#ca917184b8231394dd8847509c67a0be522e59f6"
+  integrity sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==
+
+"@scure/bip32@1.7.0", "@scure/bip32@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.7.0.tgz#b8683bab172369f988f1589640e53c4606984219"
+  integrity sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==
+  dependencies:
+    "@noble/curves" "~1.9.0"
+    "@noble/hashes" "~1.8.0"
+    "@scure/base" "~1.2.5"
+
+"@scure/bip39@1.6.0", "@scure/bip39@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.6.0.tgz#475970ace440d7be87a6086cbee77cb8f1a684f9"
+  integrity sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==
+  dependencies:
+    "@noble/hashes" "~1.8.0"
+    "@scure/base" "~1.2.5"
 
 "@scure/starknet@1.1.0":
   version "1.1.0"
@@ -1178,6 +1229,16 @@ abi-wan-kanabi@^2.2.3:
     cardinal "^2.1.1"
     fs-extra "^10.0.0"
     yargs "^17.7.2"
+
+abitype@1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.2.3.tgz#bec3e09dea97d99ef6c719140bee663a329ad1f4"
+  integrity sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==
+
+abitype@^1.2.3:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.3.0.tgz#39de89010dd7390ece44d5242a3aa80901cc193d"
+  integrity sha512-fk6Te+bojIFrMvMZrnOO+SxCB+RUksTGOzq/60ZRvs1L+BVzvi2bqt9L3W/17ZLdZsyM1FuYf65P5nlmoiH1Bg==
 
 abstract-leveldown@~0.12.0, abstract-leveldown@~0.12.1:
   version "0.12.4"
@@ -2419,6 +2480,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+eventemitter3@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
+  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
+
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
@@ -3081,6 +3147,11 @@ isomorphic-fetch@~3.0.0:
   dependencies:
     node-fetch "^2.6.1"
     whatwg-fetch "^3.4.1"
+
+isows@1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.7.tgz#1c06400b7eed216fbba3bcbd68f12490fc342915"
+  integrity sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -3872,6 +3943,20 @@ os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
+
+ox@0.14.33:
+  version "0.14.33"
+  resolved "https://registry.yarnpkg.com/ox/-/ox-0.14.33.tgz#977ab8c0692fa9240444d7db88ca026f19f81e28"
+  integrity sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==
+  dependencies:
+    "@adraffy/ens-normalize" "^1.11.0"
+    "@noble/ciphers" "^1.3.0"
+    "@noble/curves" "1.9.1"
+    "@noble/hashes" "^1.8.0"
+    "@scure/bip32" "^1.7.0"
+    "@scure/bip39" "^1.6.0"
+    abitype "^1.2.3"
+    eventemitter3 "5.0.1"
 
 p-limit@^1.1.0:
   version "1.3.0"
@@ -5246,6 +5331,20 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+viem@^2.55.10:
+  version "2.55.10"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.55.10.tgz#e9ddc7f020248210ea282012965a2a2ec0717593"
+  integrity sha512-Q9Ba+/ma81U2M5o5P2AQ7Ux8rTIwmCZvUcr8rKdQ22bV0IBFHllM2m5gWDP8hFaUN2nH2oW3QG44amRazflYNQ==
+  dependencies:
+    "@noble/curves" "1.9.1"
+    "@noble/hashes" "1.8.0"
+    "@scure/bip32" "1.7.0"
+    "@scure/bip39" "1.6.0"
+    abitype "1.2.3"
+    isows "1.0.7"
+    ox "0.14.33"
+    ws "8.21.0"
+
 vite-node@0.33.0:
   version "0.33.0"
   resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-0.33.0.tgz#c6a3a527e0b8090da7436241bc875760ae0eef28"
@@ -5383,6 +5482,11 @@ ws@7.4.6:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
+ws@8.21.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 xtend@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## Summary

Prepares snapshot.js for ENSv2 by routing all ENS resolution through the Universal Resolver and migrating the ENS helpers from ethers v5 to viem. Added support for Universal Resolver (`0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe`),  so snapshot.js keep working unchanged when v2 goes live. Readiness is verified by the official integration check (`ur.integration-tests.eth` → `0x2222...2222`), which now runs in the e2e suite.

## Changes

### ENSv2 groundwork 

- Added `ensUniversalResolver` to `networks.json` for mainnet and Sepolia.
- `getEnsOwner` now prefers `UniversalResolver.findOwner(dnsEncodedName)` (the v2-native ownership lookup that traverses the hierarchical registry) and only falls back to the v1 registry + NameWrapper unwrap when it returns nothing. This is needed for unmigrated names during the transition.
- `getEnsTextRecord` resolves through the Universal Resolver instead of querying resolvers directly.
- Added strict DNS packet encoding (`dnsEncodeName`) with empty/oversized label validation.

### viem migration of the ENS helpers 

- New memoized `getViemClient()` in `src/utils/provider.ts`, mirroring the existing brovider URL and timeout behavior.
- `getEnsTextRecord` uses viem `getEnsText`; `getEnsOwner` uses viem `readContract` for `findOwner`, the v1 registry fallback, and the NameWrapper unwrap, and viem `getEnsAddress` for the DNS-TLD and subdomain fallbacks.
- This replaces ethers v5 `provider.resolveName`, which bypassed the Universal Resolver and would fail for names upgraded to v2-native resolvers. viem handles CCIP-Read including the ENSIP-21 batch gateway.
- Name preprocessing (`normalize`, `namehash`) now comes from `viem/ens` (ENSIP-15); the `MUTED_ERRORS` ethers error-matching workaround is gone since viem returns `null` for unresolvable names.
- Removed the unused, pre-ENSIP-15 `@ensdomains/eth-ens-namehash` dependency. Non-ENS code (multicall, sign, verify) stays on ethers v5.

### Node 18 + readiness test

- `engines.node` bumped from `>=16` to `>=18` (viem requires native `fetch`; Node 16 is EOL). CI workflows pinned to Node 16 (typecheck, npm-publish, update-network, update-minor-version) now use Node 18.
- Added the official ENSv2 readiness e2e test: resolving `ur.integration-tests.eth` through the Universal Resolver must return `0x2222...2222`.

### Test stability 

- Gave the block finder e2e tests a 30s timeout; their live cross-network block lookups exceeded vitest's 5s default under full-suite parallel load.

## Breaking changes

- **Node.js >= 18 is now required.** Consumers on Node 16 must upgrade.
- No public API changes: `getEnsOwner`, `getEnsTextRecord`, `getSpaceUri`, and `getSpaceController` keep their signatures and return shapes.

## Out of scope / follow-ups

- Remove the v1 registry fallback and NameWrapper unwrap once the v2 Universal Resolver is confirmed live (for migrated names the v1 registry reports the migration controller as owner).
- Replace the v1 `ensSubgraph` URLs (needs coordination with downstream consumers).
- Longer term: migrate the remaining ethers v5 modules (multicall, sign, verify) to viem, a breaking change (`BigNumber` → `bigint`) that deserves its own major-version PR.

## Test plan

- [x] `yarn typecheck` and `yarn lint` pass
- [x] Unit tests pass (`src/utils.spec.js`, 79 tests)
- [x] Full suite passes: 23 files, 341 tests, including live e2e coverage of owned names, wrapped names (NameWrapper unwrap), subdomains, offchain CCIP names (`lucemans.cb.id`, `lucemans.uni.eth`), and DNS-imported domains (`defi.app`)
- [x] ENSv2 readiness check passes: `ur.integration-tests.eth` resolves to `0x2222222222222222222222222222222222222222` through the Universal Resolver
