### PR TITLE
fix(multicall): parse Starknet Span<felt252> outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.14.27",
+  "version": "0.14.28",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/multicall/starknet.ts
+++ b/src/multicall/starknet.ts
@@ -49,11 +49,9 @@ function parseStarknetResult(rawResult: string[], functionAbi: any): any {
         case 'core::array::Array::<core::felt252>': {
           const length = Number(num.toBigInt(rawValue));
 
-          results.push(
-            rawResult
-              .slice(rawIndex + 1, rawIndex + 1 + length)
-              .map((item) => decodeFelt252(item))
-          );
+          // Span items are opaque: only the caller knows whether they hold
+          // text, so they are returned as raw felts.
+          results.push(rawResult.slice(rawIndex + 1, rawIndex + 1 + length));
           rawIndex += 1 + length;
           break;
         }

--- a/src/multicall/starknet.ts
+++ b/src/multicall/starknet.ts
@@ -1,5 +1,18 @@
 import { num, RpcProvider, shortString, transaction, uint256 } from 'starknet';
 
+function decodeFelt252(rawValue: string): string {
+  try {
+    const decoded = shortString.decodeShortString(rawValue);
+
+    return num.toBigInt(shortString.encodeShortString(decoded)) ===
+      num.toBigInt(rawValue)
+      ? decoded
+      : rawValue;
+  } catch {
+    return rawValue;
+  }
+}
+
 /**
  * Parses the raw result from a Starknet function call based on its ABI.
  * It handles different types like felt252, u8, u256, etc., and decodes them accordingly.
@@ -29,13 +42,21 @@ function parseStarknetResult(rawResult: string[], functionAbi: any): any {
 
       switch (output.type) {
         case 'core::felt252':
-          try {
-            results.push(shortString.decodeShortString(rawValue));
-          } catch {
-            results.push(rawValue);
-          }
+          results.push(decodeFelt252(rawValue));
           rawIndex++;
           break;
+        case 'core::array::Span::<core::felt252>':
+        case 'core::array::Array::<core::felt252>': {
+          const length = Number(num.toBigInt(rawValue));
+
+          results.push(
+            rawResult
+              .slice(rawIndex + 1, rawIndex + 1 + length)
+              .map((item) => decodeFelt252(item))
+          );
+          rawIndex += 1 + length;
+          break;
+        }
         case 'core::integer::u8':
         case 'core::integer::u16':
         case 'core::integer::u32':

--- a/src/multicall/starknet.ts
+++ b/src/multicall/starknet.ts
@@ -47,6 +47,16 @@ function parseStarknetResult(rawResult: string[], functionAbi: any): any {
           break;
         case 'core::array::Span::<core::felt252>':
         case 'core::array::Array::<core::felt252>': {
+          if (rawValue === undefined) {
+            // The response ran out before this output. Degrade like every
+            // other case does rather than throwing out of the loop, which
+            // would discard the outputs already parsed. Not `[]`, which a
+            // caller cannot tell from a genuinely empty span.
+            results.push(undefined);
+            rawIndex++;
+            break;
+          }
+
           const length = Number(num.toBigInt(rawValue));
 
           // Span items are opaque: only the caller knows whether they hold

--- a/src/multicall/starknet.ts
+++ b/src/multicall/starknet.ts
@@ -1,11 +1,42 @@
 import { num, RpcProvider, shortString, transaction, uint256 } from 'starknet';
 
+/**
+ * Re-encodes a decoded short string to the felt it came from.
+ *
+ * `shortString.encodeShortString` is not a faithful inverse of
+ * `decodeShortString`: it builds the hex with `charCodeAt(0).toString(16)` and
+ * no zero padding, so every byte below `0x10` comes back one hex digit short.
+ * `0x55534409436f696e` ("USD\tCoin") re-encodes as `0x5553449436f696e`.
+ *
+ * The `0x7f` bound is the one `encodeShortString` enforces through `isASCII`,
+ * and it is load bearing rather than incidental: a felt holding a byte above
+ * `0x7f` decodes to mojibake that `BigInt()` cannot read back, so it has to
+ * stay a raw felt. Returns `undefined` when the string cannot be a felt's
+ * bytes, which is a rejection rather than a value.
+ */
+function encodeShortStringPadded(value: string): string | undefined {
+  if (value.length === 0) return undefined;
+
+  let hex = '';
+
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+
+    if (code > 0x7f) return undefined;
+
+    hex += code.toString(16).padStart(2, '0');
+  }
+
+  return `0x${hex}`;
+}
+
 function decodeFelt252(rawValue: string): string {
   try {
     const decoded = shortString.decodeShortString(rawValue);
+    const reEncoded = encodeShortStringPadded(decoded);
 
-    return num.toBigInt(shortString.encodeShortString(decoded)) ===
-      num.toBigInt(rawValue)
+    return reEncoded !== undefined &&
+      num.toBigInt(reEncoded) === num.toBigInt(rawValue)
       ? decoded
       : rawValue;
   } catch {

--- a/test/integration/multicall/starknet-id.spec.ts
+++ b/test/integration/multicall/starknet-id.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { CallData, starknetId } from 'starknet';
+import Multicaller from '../../../src/multicall/multicaller';
+import getProvider from '../../../src/utils/provider';
+
+describe('Starknet.id through Multicaller', () => {
+  const network = '0x534e5f4d41494e';
+  const provider = getProvider(network);
+
+  const NAMING_CONTRACT =
+    '0x6ac597f8116f886fa1c97a23fa4e08299975ecaf6b598873ca6792b9bbfb678';
+
+  const namingAbi = [
+    {
+      name: 'address_to_domain',
+      outputs: [{ type: 'core::array::Span::<core::felt252>' }]
+    },
+    {
+      name: 'domain_to_address',
+      outputs: [{ type: 'core::starknet::contract_address::ContractAddress' }]
+    }
+  ];
+
+  const domains = {
+    'checkpoint.stark':
+      '0x7ff6b17f07c4d83236e3fc5f94259a19d1ed41bbcf1822397ea17882e9b038d',
+    'fricoben.stark':
+      '0x61b6c0a78f9edf13cea17b50719f3344533fadd470b8cb29c2b4318014f52d3',
+    'th0rgal.stark':
+      '0xa00373a00352aa367058555149b573322910d54fcdf3a926e3e56d0dcb4b0c'
+  };
+
+  const addressWithoutDomain =
+    '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde';
+
+  const options = { limit: 50, blockTag: 12716771 };
+
+  it('should look up the domains of a batch of addresses', async () => {
+    const addresses = [...Object.values(domains), addressWithoutDomain];
+    const multicaller = new Multicaller(network, provider, namingAbi, options);
+
+    addresses.forEach((address) => {
+      multicaller.call(
+        ['domains', address],
+        NAMING_CONTRACT,
+        'address_to_domain',
+        CallData.compile({ address, hint: [] })
+      );
+    });
+
+    const result = await multicaller.execute();
+
+    expect(
+      starknetId.useDecoded(
+        result.domains[domains['checkpoint.stark']].map(BigInt)
+      )
+    ).toBe('checkpoint.stark');
+    expect(
+      starknetId.useDecoded(
+        result.domains[domains['fricoben.stark']].map(BigInt)
+      )
+    ).toBe('fricoben.stark');
+    expect(
+      starknetId.useDecoded(
+        result.domains[domains['th0rgal.stark']].map(BigInt)
+      )
+    ).toBe('th0rgal.stark');
+    expect(result.domains[addressWithoutDomain]).toEqual([]);
+  }, 20000);
+
+  it('should resolve a batch of domains to addresses', async () => {
+    const multicaller = new Multicaller(network, provider, namingAbi, options);
+
+    Object.keys(domains).forEach((domain) => {
+      multicaller.call(
+        ['addresses', domain],
+        NAMING_CONTRACT,
+        'domain_to_address',
+        CallData.compile({
+          domain: domain
+            .replace('.stark', '')
+            .split('.')
+            .map((part) => starknetId.useEncoded(part).toString(10)),
+          hint: []
+        })
+      );
+    });
+
+    const result = await multicaller.execute();
+
+    Object.entries(domains).forEach(([domain, address]) => {
+      expect(result.addresses[domain]).toBe(address);
+    });
+  }, 20000);
+});

--- a/test/multicall/starknet-decode.spec.ts
+++ b/test/multicall/starknet-decode.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { parse } from './starknet-stub';
+
+describe('multicall/starknet', () => {
+  describe('parsing felt252 outputs', () => {
+    const abi = [
+      {
+        name: 'identify',
+        outputs: [{ type: 'core::felt252' }]
+      }
+    ];
+
+    it('decodes a felt252 holding a short string', async () => {
+      const result = await parse(abi, 'identify', ['0x55534420436f696e']);
+
+      expect(result).toEqual(['USD Coin']);
+    });
+
+    it('returns the raw felt252 when it does not hold a short string', async () => {
+      const result = await parse(abi, 'identify', ['0xb5b47279a7f0c']);
+
+      expect(result).toEqual(['0xb5b47279a7f0c']);
+    });
+
+    it('returns the raw felt252 when the decoded string encodes back to a different felt', async () => {
+      const result = await parse(abi, 'identify', ['0x5553444']);
+
+      expect(result).toEqual(['0x5553444']);
+    });
+  });
+
+  describe('parsing felt252 items inside a sequence', () => {
+    it('decodes each item of a Span on its own', async () => {
+      const result = await parse(
+        [
+          {
+            name: 'address_to_domain',
+            outputs: [{ type: 'core::array::Span::<core::felt252>' }]
+          }
+        ],
+        'address_to_domain',
+        ['0x3', '0x55534420436f696e', '0x5553444', '0xb5b47279a7f0c']
+      );
+
+      expect(result).toEqual([['USD Coin', '0x5553444', '0xb5b47279a7f0c']]);
+    });
+
+    it('decodes each item of an Array on its own', async () => {
+      const result = await parse(
+        [
+          {
+            name: 'get_items',
+            outputs: [{ type: 'core::array::Array::<core::felt252>' }]
+          }
+        ],
+        'get_items',
+        ['0x3', '0xb5b47279a7f0c', '0x737461726b', '0x5553444']
+      );
+
+      expect(result).toEqual([['0xb5b47279a7f0c', 'stark', '0x5553444']]);
+    });
+  });
+});

--- a/test/multicall/starknet-decode.spec.ts
+++ b/test/multicall/starknet-decode.spec.ts
@@ -27,6 +27,42 @@ describe('multicall/starknet decoding', () => {
 
       expect(result).toEqual(['0x5553444']);
     });
+
+    it('decodes a felt252 holding a short string with a control character', async () => {
+      // Reported by @wa0x6e. `shortString.encodeShortString` emits an
+      // unpadded `charCodeAt(0).toString(16)`, so the tab re-encodes as
+      // `0x5553449436f696e`, one hex digit short, and the round-trip guard
+      // rejected a felt that master decoded.
+      const result = await parse(abi, 'identify', ['0x55534409436f696e']);
+
+      expect(result).toEqual(['USD\tCoin']);
+    });
+
+    // The whole class, not just the tab: every byte below 0x10 is one hex
+    // digit when unpadded. 0x0a and 0x0d are in here deliberately, since an
+    // encoder written as `str.replace(/./g, ...)` skips them (`.` does not
+    // match a line terminator) and would leave two of the sixteen broken.
+    const controlBytes = Array.from({ length: 0x10 }, (_, byte) => byte);
+
+    it.each(controlBytes)(
+      'decodes a felt252 whose bytes include 0x%s',
+      async (byte) => {
+        const raw = `0x555344${byte.toString(16).padStart(2, '0')}436f696e`;
+        const result = await parse(abi, 'identify', [raw]);
+
+        expect(result).toEqual([`USD${String.fromCharCode(byte)}Coin`]);
+      }
+    );
+
+    it('still returns the raw felt252 when a byte is above 0x7f', async () => {
+      // The guard's reason for existing: these decode to mojibake that
+      // `BigInt()` cannot read back. Padding the re-encode must not widen the
+      // round trip past the ASCII bound `encodeShortString` used to enforce.
+      const result = await parse(abi, 'identify', ['0xcafebabe']);
+
+      expect(result).toEqual(['0xcafebabe']);
+      expect(BigInt((result as string[])[0])).toEqual(BigInt('0xcafebabe'));
+    });
   });
 
   describe('parsing felt252 items inside a sequence', () => {

--- a/test/multicall/starknet-decode.spec.ts
+++ b/test/multicall/starknet-decode.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { parse } from './starknet-stub';
 
-describe('multicall/starknet', () => {
+describe('multicall/starknet decoding', () => {
   describe('parsing felt252 outputs', () => {
     const abi = [
       {

--- a/test/multicall/starknet-decode.spec.ts
+++ b/test/multicall/starknet-decode.spec.ts
@@ -30,7 +30,7 @@ describe('multicall/starknet', () => {
   });
 
   describe('parsing felt252 items inside a sequence', () => {
-    it('decodes each item of a Span on its own', async () => {
+    it('leaves every item of a Span raw, including one that holds a short string', async () => {
       const result = await parse(
         [
           {
@@ -42,10 +42,12 @@ describe('multicall/starknet', () => {
         ['0x3', '0x55534420436f696e', '0x5553444', '0xb5b47279a7f0c']
       );
 
-      expect(result).toEqual([['USD Coin', '0x5553444', '0xb5b47279a7f0c']]);
+      expect(result).toEqual([
+        ['0x55534420436f696e', '0x5553444', '0xb5b47279a7f0c']
+      ]);
     });
 
-    it('decodes each item of an Array on its own', async () => {
+    it('leaves every item of an Array raw, including one that holds a short string', async () => {
       const result = await parse(
         [
           {
@@ -57,7 +59,29 @@ describe('multicall/starknet', () => {
         ['0x3', '0xb5b47279a7f0c', '0x737461726b', '0x5553444']
       );
 
-      expect(result).toEqual([['0xb5b47279a7f0c', 'stark', '0x5553444']]);
+      expect(result).toEqual([
+        ['0xb5b47279a7f0c', '0x737461726b', '0x5553444']
+      ]);
+    });
+
+    it('keeps a span item convertible back to a felt when every byte is printable', async () => {
+      // 0x204d4e is the starknet.id encoding of abwab.stark. Decoding it as a
+      // short string gives ' MN', which BigInt() cannot read back.
+      const result = await parse(
+        [
+          {
+            name: 'address_to_domain',
+            outputs: [{ type: 'core::array::Span::<core::felt252>' }]
+          }
+        ],
+        'address_to_domain',
+        ['0x1', '0x204d4e']
+      );
+
+      expect(result).toEqual([['0x204d4e']]);
+      expect((result as string[][])[0].map(BigInt)).toEqual([
+        BigInt('0x204d4e')
+      ]);
     });
   });
 });

--- a/test/multicall/starknet-stub.ts
+++ b/test/multicall/starknet-stub.ts
@@ -1,0 +1,33 @@
+import multicall from '../../src/multicall/starknet';
+
+const CONTRACT =
+  '0x6ac597f8116f886fa1c97a23fa4e08299975ecaf6b598873ca6792b9bbfb678';
+const MULTICALL_ADDRESS =
+  '0x05754af3760f3356da99aea5c3ec39ccac7783d925a19666ebbeca58ff0087f4';
+
+function stubProvider(responses: string[][]) {
+  const flat = responses.flatMap((response) => [
+    `0x${response.length.toString(16)}`,
+    ...response
+  ]);
+
+  return {
+    callContract: async () => ['0x1', `0x${flat.length.toString(16)}`, ...flat]
+  } as any;
+}
+
+function call(fn: string) {
+  return [CONTRACT, fn, []];
+}
+
+export async function parse(abi: any[], fn: string, response: string[]) {
+  const results = await multicall(
+    MULTICALL_ADDRESS,
+    stubProvider([response]),
+    abi,
+    [call(fn)],
+    50
+  );
+
+  return results[0];
+}

--- a/test/multicall/starknet.spec.ts
+++ b/test/multicall/starknet.spec.ts
@@ -47,7 +47,7 @@ describe('multicall/starknet', () => {
         ['0x2', '0x55534420436f696e', '0xb5b47279a7f0c']
       );
 
-      expect(result).toEqual([['USD Coin', '0xb5b47279a7f0c']]);
+      expect(result).toEqual([['0x55534420436f696e', '0xb5b47279a7f0c']]);
     });
 
     it('keeps parsing the outputs that follow a span', async () => {

--- a/test/multicall/starknet.spec.ts
+++ b/test/multicall/starknet.spec.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { parse } from './starknet-stub';
+
+describe('multicall/starknet', () => {
+  describe('parsing Span outputs', () => {
+    const abi = [
+      {
+        name: 'address_to_domain',
+        outputs: [{ type: 'core::array::Span::<core::felt252>' }]
+      }
+    ];
+
+    it('parses a flat span of felt252', async () => {
+      const result = await parse(abi, 'address_to_domain', [
+        '0x1',
+        '0xb5b47279a7f0c'
+      ]);
+
+      expect(result).toEqual([['0xb5b47279a7f0c']]);
+    });
+
+    it('parses a span with several items', async () => {
+      const result = await parse(abi, 'address_to_domain', [
+        '0x2',
+        '0xb5b47279a7f0c',
+        '0x15d246f6c1b'
+      ]);
+
+      expect(result).toEqual([['0xb5b47279a7f0c', '0x15d246f6c1b']]);
+    });
+
+    it('parses an empty span', async () => {
+      const result = await parse(abi, 'address_to_domain', ['0x0']);
+
+      expect(result).toEqual([[]]);
+    });
+
+    it('parses an Array of felt252', async () => {
+      const result = await parse(
+        [
+          {
+            name: 'get_items',
+            outputs: [{ type: 'core::array::Array::<core::felt252>' }]
+          }
+        ],
+        'get_items',
+        ['0x2', '0x55534420436f696e', '0xb5b47279a7f0c']
+      );
+
+      expect(result).toEqual([['USD Coin', '0xb5b47279a7f0c']]);
+    });
+
+    it('keeps parsing the outputs that follow a span', async () => {
+      const result = await parse(
+        [
+          {
+            name: 'get_domain_and_owner',
+            outputs: [
+              { type: 'core::array::Span::<core::felt252>' },
+              { type: 'core::starknet::contract_address::ContractAddress' },
+              { type: 'core::bool' }
+            ]
+          }
+        ],
+        'get_domain_and_owner',
+        [
+          '0x2',
+          '0xb5b47279a7f0c',
+          '0x15d246f6c1b',
+          '0x7ff6b17f07c4d83236e3fc5f94259a19d1ed41bbcf1822397ea17882e9b038d',
+          '0x1'
+        ]
+      );
+
+      expect(result).toEqual([
+        ['0xb5b47279a7f0c', '0x15d246f6c1b'],
+        '0x7ff6b17f07c4d83236e3fc5f94259a19d1ed41bbcf1822397ea17882e9b038d',
+        true
+      ]);
+    });
+  });
+
+  describe('parsing malformed Span responses', () => {
+    const abi = [
+      {
+        name: 'address_to_domain',
+        outputs: [{ type: 'core::array::Span::<core::felt252>' }]
+      }
+    ];
+
+    it('returns the items that are there when the span declares more than the response holds', async () => {
+      const result = await parse(abi, 'address_to_domain', [
+        '0x5',
+        '0xb5b47279a7f0c'
+      ]);
+
+      expect(result).toEqual([['0xb5b47279a7f0c']]);
+    });
+
+    it('returns an empty span when the response stops at the length felt', async () => {
+      const result = await parse(abi, 'address_to_domain', ['0x2']);
+
+      expect(result).toEqual([[]]);
+    });
+
+    it('takes what is there when the length felt is larger than any real length', async () => {
+      const result = await parse(abi, 'address_to_domain', [
+        '0x800000000000011000000000000000000000000000000000000000000000000',
+        '0xb5b47279a7f0c',
+        '0x15d246f6c1b'
+      ]);
+
+      expect(result).toEqual([['0xb5b47279a7f0c', '0x15d246f6c1b']]);
+    });
+
+    it('returns the raw felts instead of throwing when the length felt is not a number', async () => {
+      const result = await parse(abi, 'address_to_domain', [
+        'not-a-felt',
+        '0xb5b47279a7f0c'
+      ]);
+
+      expect(result).toEqual(['not-a-felt', '0xb5b47279a7f0c']);
+    });
+  });
+});

--- a/test/multicall/starknet.spec.ts
+++ b/test/multicall/starknet.spec.ts
@@ -113,6 +113,29 @@ describe('multicall/starknet', () => {
       expect(result).toEqual([['0xb5b47279a7f0c', '0x15d246f6c1b']]);
     });
 
+    it('leaves the span slot empty rather than discarding the outputs already parsed', async () => {
+      const result = await parse(
+        [
+          {
+            name: 'get_owner_and_domain',
+            outputs: [
+              { type: 'core::starknet::contract_address::ContractAddress' },
+              { type: 'core::integer::u8' },
+              { type: 'core::bool' },
+              { type: 'core::array::Span::<core::felt252>' }
+            ]
+          }
+        ],
+        'get_owner_and_domain',
+        ['0xabc', '0x5', '0x1']
+      );
+
+      // `undefined`, not `[]`: a caller cannot tell an empty span from a
+      // missing one, and an empty span is a real answer here (an address
+      // with no domain).
+      expect(result).toStrictEqual(['0xabc', 5, true, undefined]);
+    });
+
     it('returns the raw felts instead of throwing when the length felt is not a number', async () => {
       const result = await parse(abi, 'address_to_domain', [
         'not-a-felt',

--- a/test/multicall/starknet.spec.ts
+++ b/test/multicall/starknet.spec.ts
@@ -136,6 +136,28 @@ describe('multicall/starknet', () => {
       expect(result).toStrictEqual(['0xabc', 5, true, undefined]);
     });
 
+    it('leaves a missing felt252 slot undefined', async () => {
+      // The parity the span guard above is measured against. It rests on
+      // `decodeFelt252(undefined)` falling through its `catch`, which is not
+      // obvious from the helper and which a later change to it could quietly
+      // break. Passes on master too, deliberately.
+      const result = await parse(
+        [
+          {
+            name: 'get_owner_and_name',
+            outputs: [
+              { type: 'core::starknet::contract_address::ContractAddress' },
+              { type: 'core::felt252' }
+            ]
+          }
+        ],
+        'get_owner_and_name',
+        ['0xabc']
+      );
+
+      expect(result).toStrictEqual(['0xabc', undefined]);
+    });
+
     it('returns the raw felts instead of throwing when the length felt is not a number', async () => {
       const result = await parse(abi, 'address_to_domain', [
         'not-a-felt',


### PR DESCRIPTION
`parseStarknetResult` had no case for `core::array::Span::<core::felt252>`, so a span output fell through to `default:`, which pushed the length felt and stopped. The Starknet multicall therefore worked in one direction and silently truncated in the other.

Measured on mainnet against the Starknet.id naming contract (`address_to_domain` really does declare `core::array::Span::<core::felt252>`, read back from the deployed class ABI):

| call | before | after |
| --- | --- | --- |
| `address_to_domain(owner of checkpoint.stark)` | `["0x1"]` | `[["0xb5b47279a7f0c"]]` -> `checkpoint.stark` |
| `address_to_domain(address with no domain)` | `["0x0"]` | `[[]]` |
| `domain_to_address("checkpoint.stark")` | `"0x7ff6b1...b038d"` | unchanged |

## Changes

Reworked to the smallest diff that fixes this, after @wa0x6e asked for less churn. `src/multicall/starknet.ts` is now +34/-5, down from +89/-62, in two hunks. The earlier revision extracted the whole per-type `switch` into a recursive `parseStarknetValue` helper, which moved most of the file. Nothing is extracted or relocated now: every case from `core::integer::u8` down, plus `partitionResponses` and `multicall()`, is byte for byte what is on `master`.

- A case for `core::array::Span::<core::felt252>` and `core::array::Array::<core::felt252>` added in place inside the existing `switch`: read the length felt, take that many items, advance the cursor past them. **The items are returned as raw felts.** A span is opaque data and only the caller knows whether the items hold text, so decoding them there is not safe: it broke reverse resolution outright for any starknet.id domain whose felt is all printable bytes, e.g. `abwab.stark` = `0x204d4e` came back as `" MN"`, which `BigInt()` cannot read back. Caught by @ChaituVR in review.
- The scalar `felt252` case no longer mangles non string felts. `master` decodes every felt as a short string, so a starknet.id encoded domain read through a `core::felt252` output came back as mojibake (`0xb5b47279a7f0c` -> `µ´ry§ðc`) that could not be turned back into the felt. The decode is now kept only when it round trips to the same felt, otherwise the raw felt is returned. This is a fix to the pre-existing scalar path and stands on its own: it is not what makes the span case work, since span items are never decoded now. `USD Coin`, `identify()` and the existing `starknet-contracts` snapshot are unaffected.
- **A guard on a missing span slot**, @ChaituVR's second point. If the response runs out before a span output, `rawValue` is `undefined`, `num.toBigInt(undefined)` throws, and the `try`/`catch` wrapping the whole parse loop returns the raw felt array, discarding every output already parsed. The guard pushes `undefined` for that slot instead and moves on. It pushes `undefined` and not `[]`, because an empty span is a legitimate answer on this contract (an address with no domain, pinned in the integration test), so `[]` would make a truncated response indistinguishable from a real empty result.

Not a breaking change. `master` has no `Span` or `Array` case at all, so no published version has ever returned span items in any form, decoded or raw.

## Scope of the missing slot guard

**It does not fix the class, and is not trying to.** `u128`, `usize`, `i128` and `u256` still abort the whole parse on a missing slot, on `master` exactly as here.

Measured, `outputs: [ContractAddress, T]` against a one felt response so that `T`'s slot is missing:

| `T` | `master` | this PR |
| --- | --- | --- |
| `Span::<felt252>`, `Array::<felt252>` | `['0xabc', undefined]` (via `default:`) | `['0xabc', undefined]` |
| `felt252`, `ContractAddress`, `ClassHash`, `bytes31`, unknown types | `['0xabc', undefined]` | unchanged |
| `u8`, `u16`, `u32`, `u64`, `i8`, `i16`, `i32`, `i64` | `['0xabc', NaN]` | unchanged |
| `bool` | `['0xabc', false]` | unchanged |
| `u128`, `usize`, `i128`, `u256` | `['0xabc']`, whole parse discarded | **unchanged, still discarded** |

So what the guard actually buys is parity, not a new capability. `master` already returned `undefined` in a missing span slot, incidentally, because a span fell through to `default:` and `default:` pushes `rawValue`. Adding the real span case is what introduced the throw. Without the guard this PR would make the span path the one type that got *worse* on a short response. With it, the span path degrades the way the other quiet types already do, and the four integer types that abort keep aborting.

## When is a response actually short

Not from a well behaved node against a matching ABI. `starknet_call` returns the full return arity the contract serialized, so a response shorter than the ABI's outputs means the ABI handed to `Multicaller` does not describe the contract that ran. That is caller error, and no parser can do better than degrade.

The one path that is not caller error is a historical block read against a contract that has gained return arity since. You hold today's ABI, the class that executed at that block returned fewer felts, and the response is legitimately short through nobody's mistake. `Multicaller` takes a `blockTag` and the integration test here uses one (block 12716771), so the shape is reachable in this repo, though the naming contract itself has not changed arity. That is the case the guard is worth having for.

## Scope

**Only flat sequences of `felt252` are handled.** `Span::<Span::<T>>` and sequences of multi slot item types such as `Span::<u256>` are not supported and keep falling through to `default:` exactly as they do today. Supporting them is what forced the recursion, and therefore the extraction, in the first revision, and no caller has one. If a caller ever does, it needs the recursive form and can be done then.

## Notes for callers

- Span items come back as raw felt strings. A caller that wants text decodes them itself, which for starknet.id means `starknetId.useDecoded(felts.map(BigInt))`.
- The `limit` default in `multicall/index.ts` is 500, which is EVM tuned. The added integration test uses 50, which is verified working. I have not measured where Starknet step limits start to bite, so callers batching many Starknet calls should set `limit` explicitly rather than rely on the default. Not changed here.
- Starknet's `aggregate` has no `tryAggregate` equivalent, so one reverting call loses the whole batch. Not a problem for this case (an unregistered name returns an empty span rather than reverting), but worth knowing.

This unblocks swapping stamp's `addressResolvers/starknet.ts` from one provider call per name to `utils.Multicaller`, which takes a 50 address lookup from 50 RPC calls to 1. Separate PR.

## Tests

Split per @wa0x6e: the multicall parsing test and the decode test are separate files. Both drive `src/multicall/starknet.ts` through a stubbed provider and touch no network (verified by running them inside an isolated network namespace).

`test/multicall/starknet-felt252.spec.ts` is renamed to **`test/multicall/starknet-decode.spec.ts`**, per @wa0x6e, so it can hold decoder tests for other types later rather than being named for one type. `starknet-` prefix plus a qualifier matches the sibling files (`starknet-contracts.spec.ts`, `starknet-id.spec.ts`). The two inner `describe` names stay `parsing felt252 outputs` and `parsing felt252 items inside a sequence` because they scope their own group and do not claim the file. 6 tests: three for the scalar round trip guard, three pinning that sequence items stay raw, including `0x204d4e` (`abwab.stark`) surviving a `.map(BigInt)`. 5 of the 6 fail on `master`, for example `expected [ 'µ´ry§ðc' ] to deeply equal [ '0xb5b47279a7f0c' ]`. `decodes a felt252 holding a short string` passes on `master` and is there to hold the existing behaviour still.

`test/multicall/starknet.spec.ts` (10 tests). `parsing Span outputs` (5): flat span, multi item span, empty span, `Array::<felt252>`, and outputs following a span.

`parsing malformed Span responses` (5, per @wa0x6e asking for the error path). Every assertion here was measured first, then written down.

| response | result | pins |
| --- | --- | --- |
| `['0x5', '0xb5b47279a7f0c']` | `[['0xb5b47279a7f0c']]` | declared length longer than the response: `slice` clamps, no throw |
| `['0x2']` | `[[]]` | response ends at the length felt |
| `['0x8000...0000', a, b]` | `[[a, b]]` | a length felt near the felt prime clamps rather than hanging or allocating |
| `['not-a-felt', '0xb5b47279a7f0c']` | `['not-a-felt', '0xb5b47279a7f0c']` | `num.toBigInt` throws, the existing `try`/`catch` in `parseStarknetResult` contains it, the raw felts come back and `multicall()` resolves rather than rejecting |

The fifth is the guard: `outputs: [ContractAddress, u8, bool, Span]` against `['0xabc', '0x5', '0x1']` gives `['0xabc', 5, true, undefined]`. It asserts with `toStrictEqual`, so `undefined` in the fourth slot is checked rather than a missing element.

9 of the 10 in this file fail on `master`, where any span output returns the length felt and stops. The guard test is the one that passes on `master`, deliberately: it pins parity with the `undefined` that `master`'s `default:` already produced. It fails against this branch with the span case but without the guard, which is what it is really protecting, with `expected [ '0xabc', '0x5', '0x1' ] to strictly equal [ '0xabc', 5, true, undefined ]`, the whole parse thrown away.

`test/integration/multicall/starknet-id.spec.ts` (real chain, pinned to block 12716771): both directions through `utils.Multicaller` for `checkpoint.stark`, `fricoben.stark`, `th0rgal.stark`, plus an address with no domain. Untouched, and its `expect(result.domains[addressWithoutDomain]).toEqual([])` is the assertion that makes `undefined` rather than `[]` the right choice above.

## Still open, not fixed here

A corrupt length felt eats the outputs that follow it, where before it only lost them. `outputs: [Span, ContractAddress]` against `['0x3', domain, addr]` puts `addr` inside the span and leaves `undefined` in the address slot. Strictly better than `master`, which returned `['0x3']` and dropped everything, and Starknet serialization does not produce a lying length felt on a well behaved chain, so I have left it. Throwing on `rawIndex + 1 + length > rawResult.length` is the alternative if @wa0x6e wants it.

The truncation clamp means a caller cannot tell a truncated span from a genuinely short one. Same ambiguity as the existing empty span case, called out rather than hidden.

`test/multicall/starknet-stub.ts` is the one thing the two unit test files share: a `parse(abi, fn, response)` that wraps a canned `aggregate` response in a stub provider. No assertions live in it.

The nested span and `Span::<u256>` tests from the earlier revision stay dropped rather than left asserting behaviour that is no longer supported.

`yarn lint`, `yarn typecheck`, `yarn build` and `yarn test:once` (26 files, 358 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
