### PR TITLE
chore: add viem with client factory and build support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "cross-fetch": "^3.1.6",
     "json-to-graphql-query": "^2.2.4",
     "lodash.set": "^4.3.2",
-    "starknet": "^6.11.0"
+    "starknet": "^6.11.0",
+    "viem": "^2.55.11"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^18.1.0",

--- a/rollup.cjs.config.js
+++ b/rollup.cjs.config.js
@@ -4,7 +4,10 @@ import { string } from 'rollup-plugin-string';
 import pkg from './package.json';
 
 const input = 'src/index.ts';
-const external = [...Object.keys(pkg.dependencies || {})];
+const dependencies = [...Object.keys(pkg.dependencies || {})];
+// match subpath imports too (e.g. viem/ens)
+const external = (id) =>
+  dependencies.some((dep) => id === dep || id.startsWith(`${dep}/`));
 
 export default [
   {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,10 @@ import pkg from './package.json';
 
 const name = 'snapshot';
 const input = 'src/index.ts';
-const external = [...Object.keys(pkg.dependencies || {})];
+const dependencies = [...Object.keys(pkg.dependencies || {})];
+// match subpath imports too (e.g. viem/ens)
+const external = (id) =>
+  dependencies.some((dep) => id === dep || id.startsWith(`${dep}/`));
 
 export default [
   {
@@ -22,6 +25,9 @@ export default [
         name,
         file: pkg.browser,
         format: 'umd',
+        // viem uses dynamic import() internally (CCIP-Read module), which
+        // rollup would otherwise code-split — unsupported in UMD bundles
+        inlineDynamicImports: true,
         intro:
           'var global = typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {}'
       }

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -1,6 +1,5 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { RpcProvider } from 'starknet';
-import { createPublicClient, http, PublicClient } from 'viem';
 import networks from '../networks.json';
 
 export interface ProviderOptions {
@@ -10,7 +9,7 @@ export interface ProviderOptions {
 
 type ProviderInstance = StaticJsonRpcProvider | RpcProvider;
 
-type ProviderType = 'evm' | 'starknet';
+export type ProviderType = 'evm' | 'starknet';
 
 const DEFAULT_BROVIDER_URL = 'https://rpc.snapshot.org' as const;
 const DEFAULT_TIMEOUT = 25000 as const;
@@ -25,7 +24,7 @@ const providerFnMap: Record<
   starknet: getStarknetProvider
 };
 
-function normalizeOptions(
+export function normalizeOptions(
   options: ProviderOptions = {}
 ): Required<ProviderOptions> {
   return {
@@ -34,7 +33,7 @@ function normalizeOptions(
   };
 }
 
-function getBroviderNetworkId(network: string | number): string {
+export function getBroviderNetworkId(network: string | number): string {
   const config = networks[network];
   if (!config) {
     throw new Error(`Network '${network}' is not supported`);
@@ -42,11 +41,11 @@ function getBroviderNetworkId(network: string | number): string {
   return config.broviderId || String(network);
 }
 
-function getProviderType(network: string | number): ProviderType {
+export function getProviderType(network: string | number): ProviderType {
   return networks[network]?.starknet ? 'starknet' : 'evm';
 }
 
-function createMemoKey(
+export function createMemoKey(
   networkId: string,
   options: Required<ProviderOptions>
 ): string {
@@ -72,35 +71,6 @@ export default function getProvider(
 
   providerMemo.set(memoKey, provider);
   return provider;
-}
-
-const viemClientMemo = new Map<string, PublicClient>();
-
-export function getViemClient(
-  network: string | number,
-  options: ProviderOptions = {}
-): PublicClient {
-  if (getProviderType(network) !== 'evm') {
-    throw new Error(`Network '${network}' is not supported`);
-  }
-
-  const networkId = getBroviderNetworkId(network);
-  const normalizedOptions = normalizeOptions(options);
-  const memoKey = createMemoKey(networkId, normalizedOptions);
-
-  const memoized = viemClientMemo.get(memoKey);
-  if (memoized) {
-    return memoized;
-  }
-
-  const client = createPublicClient({
-    transport: http(`${normalizedOptions.broviderUrl}/${networkId}`, {
-      timeout: normalizedOptions.timeout
-    })
-  });
-
-  viemClientMemo.set(memoKey, client);
-  return client;
 }
 
 function getEvmProvider(

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -80,6 +80,10 @@ export function getViemClient(
   network: string | number,
   options: ProviderOptions = {}
 ): PublicClient {
+  if (getProviderType(network) !== 'evm') {
+    throw new Error(`Network '${network}' is not supported`);
+  }
+
   const networkId = getBroviderNetworkId(network);
   const normalizedOptions = normalizeOptions(options);
   const memoKey = createMemoKey(networkId, normalizedOptions);

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -1,5 +1,6 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { RpcProvider } from 'starknet';
+import { createPublicClient, http, PublicClient } from 'viem';
 import networks from '../networks.json';
 
 export interface ProviderOptions {
@@ -71,6 +72,31 @@ export default function getProvider(
 
   providerMemo.set(memoKey, provider);
   return provider;
+}
+
+const viemClientMemo = new Map<string, PublicClient>();
+
+export function getViemClient(
+  network: string | number,
+  options: ProviderOptions = {}
+): PublicClient {
+  const networkId = getBroviderNetworkId(network);
+  const normalizedOptions = normalizeOptions(options);
+  const memoKey = createMemoKey(networkId, normalizedOptions);
+
+  const memoized = viemClientMemo.get(memoKey);
+  if (memoized) {
+    return memoized;
+  }
+
+  const client = createPublicClient({
+    transport: http(`${normalizedOptions.broviderUrl}/${networkId}`, {
+      timeout: normalizedOptions.timeout
+    })
+  });
+
+  viemClientMemo.set(memoKey, client);
+  return client;
 }
 
 function getEvmProvider(

--- a/src/utils/viem.ts
+++ b/src/utils/viem.ts
@@ -1,0 +1,41 @@
+import { createPublicClient, http, PublicClient } from 'viem';
+import {
+  ProviderOptions,
+  createMemoKey,
+  getBroviderNetworkId,
+  getProviderType,
+  normalizeOptions
+} from './provider';
+
+// Kept out of ./provider on purpose: that module is loaded from the package
+// entry point, and a top-level viem import there would make every consumer
+// eagerly initialize viem (see the dist entry assertions in
+// test/integration/utils/dist-entry.spec.ts)
+const viemClientMemo = new Map<string, PublicClient>();
+
+export function getViemClient(
+  network: string | number,
+  options: ProviderOptions = {}
+): PublicClient {
+  if (getProviderType(network) !== 'evm') {
+    throw new Error(`Network '${network}' is not supported`);
+  }
+
+  const networkId = getBroviderNetworkId(network);
+  const normalizedOptions = normalizeOptions(options);
+  const memoKey = createMemoKey(networkId, normalizedOptions);
+
+  const memoized = viemClientMemo.get(memoKey);
+  if (memoized) {
+    return memoized;
+  }
+
+  const client = createPublicClient({
+    transport: http(`${normalizedOptions.broviderUrl}/${networkId}`, {
+      timeout: normalizedOptions.timeout
+    })
+  });
+
+  viemClientMemo.set(memoKey, client);
+  return client;
+}

--- a/test/e2e/utils.spec.js
+++ b/test/e2e/utils.spec.js
@@ -5,10 +5,26 @@ import {
   getUDNameOwner,
   getSpaceController
 } from '../../src/utils';
+import { getViemClient } from '../../src/utils/provider';
 
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
+const ENS_UNIVERSAL_RESOLVER = '0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe';
 
 describe('utils', () => {
+  // See https://docs.ens.domains/web/ensv2-readiness/
+  // 0x1111...1111 would mean resolution bypasses the Universal Resolver
+  describe('ENSv2 readiness', () => {
+    test('resolve names through the Universal Resolver', async () => {
+      const client = getViemClient('1');
+      await expect(
+        client.getEnsAddress({
+          name: 'ur.integration-tests.eth',
+          universalResolverAddress: ENS_UNIVERSAL_RESOLVER
+        })
+      ).resolves.toBe('0x2222222222222222222222222222222222222222');
+    });
+  });
+
   describe('getSpaceController', () => {
     test('return the controller address for mainnet', async () => {
       await expect(getSpaceController('psydao.eth', '1')).resolves.toBe(

--- a/test/e2e/utils.spec.js
+++ b/test/e2e/utils.spec.js
@@ -5,7 +5,7 @@ import {
   getUDNameOwner,
   getSpaceController
 } from '../../src/utils';
-import { getViemClient } from '../../src/utils/provider';
+import { getViemClient } from '../../src/utils/viem';
 
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 const ENS_UNIVERSAL_RESOLVER = '0xeEeEEEeE14D718C2B47D9923Deab1335E144EeEe';

--- a/test/e2e/utils/blockfinder.spec.ts
+++ b/test/e2e/utils/blockfinder.spec.ts
@@ -12,7 +12,7 @@ describe('Test block finder', () => {
       '137': 45609596,
       '11155111': 3979201
     });
-  });
+  }, 30000);
   test('getSnapshots should return all latest if snapshot is latest', async () => {
     expect(
       await getSnapshots('1', 'latest', provider, ['11155111', '137'])
@@ -20,5 +20,5 @@ describe('Test block finder', () => {
       '137': 'latest',
       '11155111': 'latest'
     });
-  });
+  }, 30000);
 });

--- a/test/integration/utils/dist-entry.spec.ts
+++ b/test/integration/utils/dist-entry.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest';
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import pkg from '../../../package.json';
+
+// viem must only load when getViemClient is actually used — a bare viem
+// import reachable from the entry point makes every consumer pay its
+// initialization cost at require() time
+describe('package entry points', () => {
+  const entries = [
+    { name: 'cjs', file: pkg.main },
+    { name: 'esm', file: pkg.module }
+  ];
+
+  entries.forEach(({ name, file }) => {
+    const path = join(__dirname, '../../..', file);
+    const testIfBuilt = existsSync(path) ? test : test.skip;
+
+    testIfBuilt(`${name} entry does not eagerly load viem`, () => {
+      const content = readFileSync(path, 'utf8');
+      expect(content).not.toMatch(/require\(['"]viem['"]\)/);
+      expect(content).not.toMatch(/(?:^|[\s;])import\s+['"]viem['"]/);
+      expect(content).not.toMatch(/from\s+['"]viem['"]/);
+    });
+  });
+});

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
-import getProvider, { getViemClient } from '../../../src/utils/provider';
+import getProvider from '../../../src/utils/provider';
+import { getViemClient } from '../../../src/utils/viem';
 import { RpcProvider } from 'starknet';
 
 describe('test providers', () => {

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -90,6 +90,21 @@ describe('test providers', () => {
       );
     });
 
+    test('should throw an error for non-EVM networks', () => {
+      expect(() => getViemClient('0x534e5f4d41494e')).toThrowError(
+        "Network '0x534e5f4d41494e' is not supported"
+      );
+    });
+
+    test('should memoize clients with same network and options', () => {
+      const client1 = getViemClient('1');
+      const client2 = getViemClient('1');
+      const client3 = getViemClient(1); // Different type but same network
+
+      expect(client1).toBe(client2);
+      expect(client1).toBe(client3);
+    });
+
     test('should create different instances for different options', () => {
       const client1 = getViemClient('1');
       const client2 = getViemClient('1', { timeout: 30000 });

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import getProvider from '../../../src/utils/provider';
+import getProvider, { getViemClient } from '../../../src/utils/provider';
 import { RpcProvider } from 'starknet';
 
 describe('test providers', () => {
@@ -72,6 +72,36 @@ describe('test providers', () => {
       expect(ethProvider).not.toBe(bscProvider);
       expect(ethProvider).not.toBe(starknetProvider);
       expect(bscProvider).not.toBe(starknetProvider);
+    });
+  });
+
+  describe('getViemClient()', () => {
+    test('should return a client for EVM networks', async () => {
+      expect(getViemClient('1').getChainId()).resolves.toBe(1);
+    });
+
+    test('should accept a network param as number', async () => {
+      expect(getViemClient(1).getChainId()).resolves.toBe(1);
+    });
+
+    test('should throw an error for unsupported networks', () => {
+      expect(() => getViemClient('0x123')).toThrowError(
+        "Network '0x123' is not supported"
+      );
+    });
+
+    test('should create different instances for different options', () => {
+      const client1 = getViemClient('1');
+      const client2 = getViemClient('1', { timeout: 30000 });
+      const client3 = getViemClient('1', { broviderUrl: 'https://custom.rpc' });
+
+      expect(client1).not.toBe(client2);
+      expect(client1).not.toBe(client3);
+      expect(client2).not.toBe(client3);
+    });
+
+    test('should create separate instances for different networks', () => {
+      expect(getViemClient('1')).not.toBe(getViemClient('56'));
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@adraffy/ens-normalize@^1.11.0":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz#6c2d657d4b2dfb37f8ea811dcb3e60843d4ac24a"
+  integrity sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==
+
 "@ampproject/remapping@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.1.tgz#99e8e11851128b8702cd57c33684f1d0f260b630"
@@ -755,6 +760,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@noble/ciphers@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@noble/ciphers/-/ciphers-1.3.0.tgz#f64b8ff886c240e644e5573c097f86e5b43676dc"
+  integrity sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==
+
 "@noble/curves@1.7.0", "@noble/curves@~1.7.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.7.0.tgz#0512360622439256df892f21d25b388f52505e45"
@@ -762,10 +772,29 @@
   dependencies:
     "@noble/hashes" "1.6.0"
 
+"@noble/curves@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.1.tgz#9654a0bc6c13420ae252ddcf975eaf0f58f0a35c"
+  integrity sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==
+  dependencies:
+    "@noble/hashes" "1.8.0"
+
+"@noble/curves@~1.9.0":
+  version "1.9.7"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.7.tgz#79d04b4758a43e4bca2cbdc62e7771352fa6b951"
+  integrity sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==
+  dependencies:
+    "@noble/hashes" "1.8.0"
+
 "@noble/hashes@1.6.0":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.6.0.tgz#d4bfb516ad6e7b5111c216a5cc7075f4cf19e6c5"
   integrity sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==
+
+"@noble/hashes@1.8.0", "@noble/hashes@^1.8.0", "@noble/hashes@~1.8.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
+  integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
 
 "@noble/hashes@~1.6.0":
   version "1.6.1"
@@ -908,6 +937,28 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.1.tgz#dd0b2a533063ca612c17aa9ad26424a2ff5aa865"
   integrity sha512-DGmGtC8Tt63J5GfHgfl5CuAXh96VF/LD8K9Hr/Gv0J2lAoRGlPOMpqMpMbCTOoOJMZCk2Xt+DskdDyn6dEFdzQ==
+
+"@scure/base@~1.2.5":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.6.tgz#ca917184b8231394dd8847509c67a0be522e59f6"
+  integrity sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==
+
+"@scure/bip32@1.7.0", "@scure/bip32@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.7.0.tgz#b8683bab172369f988f1589640e53c4606984219"
+  integrity sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==
+  dependencies:
+    "@noble/curves" "~1.9.0"
+    "@noble/hashes" "~1.8.0"
+    "@scure/base" "~1.2.5"
+
+"@scure/bip39@1.6.0", "@scure/bip39@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.6.0.tgz#475970ace440d7be87a6086cbee77cb8f1a684f9"
+  integrity sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==
+  dependencies:
+    "@noble/hashes" "~1.8.0"
+    "@scure/base" "~1.2.5"
 
 "@scure/starknet@1.1.0":
   version "1.1.0"
@@ -1178,6 +1229,16 @@ abi-wan-kanabi@^2.2.3:
     cardinal "^2.1.1"
     fs-extra "^10.0.0"
     yargs "^17.7.2"
+
+abitype@1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.2.3.tgz#bec3e09dea97d99ef6c719140bee663a329ad1f4"
+  integrity sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==
+
+abitype@^1.2.3:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.3.0.tgz#39de89010dd7390ece44d5242a3aa80901cc193d"
+  integrity sha512-fk6Te+bojIFrMvMZrnOO+SxCB+RUksTGOzq/60ZRvs1L+BVzvi2bqt9L3W/17ZLdZsyM1FuYf65P5nlmoiH1Bg==
 
 abstract-leveldown@~0.12.0, abstract-leveldown@~0.12.1:
   version "0.12.4"
@@ -2419,6 +2480,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+eventemitter3@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
+  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
+
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
@@ -3081,6 +3147,11 @@ isomorphic-fetch@~3.0.0:
   dependencies:
     node-fetch "^2.6.1"
     whatwg-fetch "^3.4.1"
+
+isows@1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.7.tgz#1c06400b7eed216fbba3bcbd68f12490fc342915"
+  integrity sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -3872,6 +3943,20 @@ os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
+
+ox@0.14.33:
+  version "0.14.33"
+  resolved "https://registry.yarnpkg.com/ox/-/ox-0.14.33.tgz#977ab8c0692fa9240444d7db88ca026f19f81e28"
+  integrity sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==
+  dependencies:
+    "@adraffy/ens-normalize" "^1.11.0"
+    "@noble/ciphers" "^1.3.0"
+    "@noble/curves" "1.9.1"
+    "@noble/hashes" "^1.8.0"
+    "@scure/bip32" "^1.7.0"
+    "@scure/bip39" "^1.6.0"
+    abitype "^1.2.3"
+    eventemitter3 "5.0.1"
 
 p-limit@^1.1.0:
   version "1.3.0"
@@ -5246,6 +5331,20 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+viem@^2.55.11:
+  version "2.55.11"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.55.11.tgz#50aba8e3a686866549e090f111026375d85d914b"
+  integrity sha512-RR5MwtdUnFfqw6ZGoFptizywyLOkLuhTL7UafoP3Irf2upXpANakQkLgGqY4H7A7+8JBxjUs6lElGF5zuGjMEw==
+  dependencies:
+    "@noble/curves" "1.9.1"
+    "@noble/hashes" "1.8.0"
+    "@scure/bip32" "1.7.0"
+    "@scure/bip39" "1.6.0"
+    abitype "1.2.3"
+    isows "1.0.7"
+    ox "0.14.33"
+    ws "8.21.0"
+
 vite-node@0.33.0:
   version "0.33.0"
   resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-0.33.0.tgz#c6a3a527e0b8090da7436241bc875760ae0eef28"
@@ -5383,6 +5482,11 @@ ws@7.4.6:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
+ws@8.21.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 xtend@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## What

Infrastructure groundwork for ENS v2 / Universal Resolver support (planned successor to #1217), with no production code paths touched:

- **viem `^2.55.11`** — the library ENS's v2-readiness guidance is built around: automatic CCIP-Read (EIP-3668) handling and first-class Universal Resolver support. Requires the Node ≥ 18 floor that landed in #1220.
- **Rollup: dependency subpath imports treated as external.** `external` was an exact-name array, so an import like `viem/ens` would get bundled into the published cjs/esm dist instead of staying a runtime `require`. Now any subpath of a declared dependency is external (general fix, not viem-specific).
- **Rollup: `inlineDynamicImports` for the UMD build.** viem's CCIP-Read module loads via dynamic `import()`; rollup's default is code-splitting, which the single-file UMD format cannot do.
- **`getViemClient()`** in `src/utils/provider.ts` — memoized viem `PublicClient` per network, same brovider URL + timeout conventions as the existing `getProvider()`. Deliberately chain-less so the Universal Resolver address always comes from our config, never from viem's chain defaults (calls without an explicit address fail loudly).
- **Tests**: integration tests for `getViemClient` mirroring the `getProvider()` suite, plus the official [ENSv2 readiness canary](https://docs.ens.domains/web/ensv2-readiness/) as an e2e test — `ur.integration-tests.eth` must resolve to `0x2222…2222` through the Universal Resolver (`0x1111…1111` would mean the resolution stack bypasses it).
- **Test infra**: 30s timeouts on two slow live-RPC blockfinder e2e tests (from #1217).

## Why a separate PR

Keeps the upcoming ENS PR focused purely on resolution behavior (config + `utils.ts`), while the dependency/build/plumbing surface gets reviewed on its own. Nothing here changes runtime behavior for any consumer.

## How to test

**Before (master):**
1. `grep -n "external" rollup.config.js` → exact-name array; a `viem/ens` import would be bundled into dist
2. No viem anywhere; no ENSv2 readiness check in the suite

**After (this branch):**
1. `yarn && yarn typecheck && yarn lint && yarn build` → all green; `dist/snapshot.cjs.js` contains no bundled viem code (subpath externals working)
2. `yarn test:once` → full suite green including the new `getViemClient` tests and the live ENSv2 readiness canary against mainnet
3. `git diff master --stat` → build/plumbing/test files only; `src/utils.ts` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)