### PR TITLE
fix(provider): honour the timeout option on Starknet providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cross-fetch": "^3.1.6",
     "json-to-graphql-query": "^2.2.4",
     "lodash.set": "^4.3.2",
-    "starknet": "^6.11.0",
+    "starknet": "^6.21.0",
     "viem": "^2.55.11"
   },
   "devDependencies": {

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,0 +1,73 @@
+export type FetchLike = (
+  input: RequestInfo | URL,
+  init?: RequestInit
+) => Promise<Response>;
+
+export interface WithTimeoutOptions {
+  // For callers whose stack constrains the error type, e.g. starknet's
+  // RpcChannel. The default is a plain `Error`.
+  timeoutError?: (timeout: number) => Error;
+}
+
+const defaultTimeoutError = (timeout: number) =>
+  new Error(`Request timeout after ${timeout}ms`);
+
+// Not `AbortSignal.timeout`: it would raise the browser bundle's floor to
+// Safari 16.
+export function withTimeout(
+  fetchFn: FetchLike,
+  timeout: number,
+  { timeoutError = defaultTimeoutError }: WithTimeoutOptions = {}
+): FetchLike {
+  // Without this, `setTimeout(..., 0)` aborts every request on the next tick.
+  if (timeout <= 0) return fetchFn;
+
+  return async (url, init) => {
+    const controller = new AbortController();
+    const callerSignal = init?.signal;
+    const abortFromCaller = () => controller.abort(callerSignal?.reason);
+    let timedOut = false;
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      callerSignal?.removeEventListener('abort', abortFromCaller);
+    };
+    // Cleans up after itself: nothing else will if the body is never read.
+    const timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+      cleanup();
+    }, timeout);
+    // Node-only: browser timers are numbers with no `unref`. Without this,
+    // an unread response body holds the event loop open for the full
+    // timeout even though the request already finished.
+    if (typeof timer === 'object' && 'unref' in timer) timer.unref();
+
+    if (callerSignal?.aborted) abortFromCaller();
+    else callerSignal?.addEventListener('abort', abortFromCaller);
+
+    let response: Response;
+    try {
+      response = await fetchFn(url, { ...init, signal: controller.signal });
+    } catch (e) {
+      cleanup();
+      throw timedOut ? timeoutError(timeout) : e;
+    }
+
+    // Resolving only means the headers arrived: a caller reading the body
+    // afterwards with its own `.json()` gets no bound from node-fetch on the
+    // body stream or the parse. Hold the deadline until that settles.
+    const json = response.json.bind(response);
+    response.json = async () => {
+      try {
+        return await json();
+      } catch (e) {
+        throw timedOut ? timeoutError(timeout) : e;
+      } finally {
+        cleanup();
+      }
+    };
+
+    return response;
+  };
+}

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -14,13 +14,15 @@ const defaultTimeoutError = (timeout: number) =>
 
 // Every body reader a `Response` may carry, patched only where it exists:
 // node-fetch 2 ships no `formData`, and a hand-rolled test double has only
-// the reader it needs.
-export const BODY_READERS: readonly (keyof Response)[] = [
+// the reader it needs. `bytes` is spelled out because TypeScript's DOM lib
+// does not carry it yet, though Node 22 does.
+export const BODY_READERS: readonly (keyof Response | 'bytes')[] = [
   'json',
   'text',
   'arrayBuffer',
   'blob',
-  'formData'
+  'formData',
+  'bytes'
 ];
 
 // Not `AbortSignal.timeout`: it would raise the browser bundle's floor to

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -4,8 +4,8 @@ export type FetchLike = (
 ) => Promise<Response>;
 
 export interface WithTimeoutOptions {
-  // For callers whose stack constrains the error type, e.g. starknet's
-  // RpcChannel. The default is a plain `Error`.
+  // For callers whose stack constrains the error type. The default is a
+  // plain `Error`.
   timeoutError?: (timeout: number) => Error;
 }
 
@@ -15,7 +15,13 @@ const defaultTimeoutError = (timeout: number) =>
 // Every body reader a `Response` may carry, patched only where it exists:
 // node-fetch 2 ships no `formData`, and a hand-rolled test double has only
 // the reader it needs.
-const BODY_READERS = ['json', 'text', 'arrayBuffer', 'blob', 'formData'];
+export const BODY_READERS: readonly (keyof Response)[] = [
+  'json',
+  'text',
+  'arrayBuffer',
+  'blob',
+  'formData'
+];
 
 // Not `AbortSignal.timeout`: it would raise the browser bundle's floor to
 // Safari 16.

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -19,7 +19,9 @@ export function withTimeout(
   timeout: number,
   { timeoutError = defaultTimeoutError }: WithTimeoutOptions = {}
 ): FetchLike {
-  // Without this, `setTimeout(..., 0)` aborts every request on the next tick.
+  // A precondition of the primitive, not a live path: the only caller in this
+  // repo gates the install above 0. Without it, `setTimeout(..., 0)` would
+  // abort every request on the next tick.
   if (timeout <= 0) return fetchFn;
 
   return async (url, init) => {

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -12,6 +12,11 @@ export interface WithTimeoutOptions {
 const defaultTimeoutError = (timeout: number) =>
   new Error(`Request timeout after ${timeout}ms`);
 
+// Every body reader a `Response` may carry, patched only where it exists:
+// node-fetch 2 ships no `formData`, and a hand-rolled test double has only
+// the reader it needs.
+const BODY_READERS = ['json', 'text', 'arrayBuffer', 'blob', 'formData'];
+
 // Not `AbortSignal.timeout`: it would raise the browser bundle's floor to
 // Safari 16.
 export function withTimeout(
@@ -56,19 +61,30 @@ export function withTimeout(
       throw timedOut ? timeoutError(timeout) : e;
     }
 
-    // Resolving only means the headers arrived: a caller reading the body
-    // afterwards with its own `.json()` gets no bound from node-fetch on the
-    // body stream or the parse. Hold the deadline until that settles.
-    const json = response.json.bind(response);
-    response.json = async () => {
-      try {
-        return await json();
-      } catch (e) {
-        throw timedOut ? timeoutError(timeout) : e;
-      } finally {
-        cleanup();
-      }
-    };
+    // Resolving only means the headers arrived: the body stream and the parse
+    // that follow are bounded by nothing. Hold the deadline over whichever
+    // reader the caller picks, so the deadline covers all of them and each one
+    // reports it the same way. Reading `response.body` as a stream is the one
+    // path this cannot reach; that still surfaces the raw abort.
+    const readers = response as unknown as Record<
+      string,
+      undefined | (() => Promise<unknown>)
+    >;
+    for (const name of BODY_READERS) {
+      const read = readers[name];
+      if (typeof read !== 'function') continue;
+
+      const bound = read.bind(response);
+      readers[name] = async () => {
+        try {
+          return await bound();
+        } catch (e) {
+          throw timedOut ? timeoutError(timeout) : e;
+        } finally {
+          cleanup();
+        }
+      };
+    }
 
     return response;
   };

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -155,6 +155,10 @@ function getStarknetProvider(
 ): RpcProvider {
   return new RpcProvider({
     nodeUrl: `${options.broviderUrl}/${networkKey}`,
-    baseFetch: withTimeout(crossFetch, options.timeout)
+    // `undefined` leaves starknet its own transport (`baseFetch ?? ponyfill`):
+    // with no timeout to add, swapping in crossFetch would only cost the
+    // caller a transport and the ceiling that comes with the stock one.
+    baseFetch:
+      options.timeout > 0 ? withTimeout(crossFetch, options.timeout) : undefined
   });
 }

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -101,7 +101,9 @@ type BaseFetch = NonNullable<RpcProviderOptions['baseFetch']>;
 // Not `AbortSignal.timeout`: it would raise the browser bundle's floor to
 // Safari 16.
 export function withTimeout(baseFetch: BaseFetch, timeout: number): BaseFetch {
-  // Without this, `setTimeout(..., 0)` aborts every request on the next tick.
+  // getStarknetProvider never calls in at 0, so this is the export's own
+  // precondition rather than a live path: without it, `setTimeout(..., 0)`
+  // would abort every request on the next tick.
   if (timeout <= 0) return baseFetch;
 
   return async (url, init) => {

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -1,5 +1,6 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
-import { LibraryError, RpcProvider, RpcProviderOptions } from 'starknet';
+import { LibraryError, RpcProvider } from 'starknet';
+import { withTimeout } from './fetch';
 import networks from '../networks.json';
 
 export interface ProviderOptions {
@@ -96,71 +97,13 @@ function getEvmProvider(
   );
 }
 
-type BaseFetch = NonNullable<RpcProviderOptions['baseFetch']>;
-
-// Not `AbortSignal.timeout`: it would raise the browser bundle's floor to
-// Safari 16.
-export function withTimeout(baseFetch: BaseFetch, timeout: number): BaseFetch {
-  // getStarknetProvider never calls in at 0, so this is the export's own
-  // precondition rather than a live path: without it, `setTimeout(..., 0)`
-  // would abort every request on the next tick.
-  if (timeout <= 0) return baseFetch;
-
-  return async (url, init) => {
-    const controller = new AbortController();
-    const callerSignal = init?.signal;
-    const abortFromCaller = () => controller.abort(callerSignal?.reason);
-    let timedOut = false;
-
-    const cleanup = () => {
-      clearTimeout(timer);
-      callerSignal?.removeEventListener('abort', abortFromCaller);
-    };
-    // Cleans up after itself: nothing else will if the body is never read.
-    const timer = setTimeout(() => {
-      timedOut = true;
-      controller.abort();
-      cleanup();
-    }, timeout);
-    // Node-only: browser timers are numbers with no `unref`. Without this,
-    // an unread response body holds the event loop open for the full
-    // timeout even though the request already finished.
-    if (typeof timer === 'object' && 'unref' in timer) timer.unref();
-
-    // LibraryError specifically: RpcChannel#errorHandler re-throws anything
-    // else as a bare `Error(message)`, which would drop `code`.
-    const timeoutError = () =>
-      Object.assign(new LibraryError(`Request timeout after ${timeout}ms`), {
-        code: 'TIMEOUT'
-      });
-
-    if (callerSignal?.aborted) abortFromCaller();
-    else callerSignal?.addEventListener('abort', abortFromCaller);
-
-    let response: Response;
-    try {
-      response = await baseFetch(url, { ...init, signal: controller.signal });
-    } catch (e) {
-      cleanup();
-      throw timedOut ? timeoutError() : e;
-    }
-
-    // Resolving only means the headers arrived; nothing bounds the body stream
-    // or the parse that follow. Hold the deadline over RpcChannel's read.
-    const json = response.json.bind(response);
-    response.json = async () => {
-      try {
-        return await json();
-      } catch (e) {
-        throw timedOut ? timeoutError() : e;
-      } finally {
-        cleanup();
-      }
-    };
-
-    return response;
-  };
-}
+// LibraryError specifically: RpcChannel#errorHandler re-throws anything else
+// as a bare `Error(message)`, which would drop `code`. Nothing outside this
+// call site needs it, so it stays out of the primitive.
+const starknetTimeoutError = (timeout: number) =>
+  Object.assign(new LibraryError(`Request timeout after ${timeout}ms`), {
+    code: 'TIMEOUT'
+  });
 
 function getStarknetProvider(
   networkKey: string,
@@ -176,7 +119,9 @@ function getStarknetProvider(
     // connection reuse), an XHR ponyfill in the bundled browser build.
     baseFetch:
       options.timeout > 0
-        ? withTimeout(fetch.bind(globalThis), options.timeout)
+        ? withTimeout(fetch.bind(globalThis), options.timeout, {
+            timeoutError: starknetTimeoutError
+          })
         : undefined
   });
 }

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -123,6 +123,10 @@ export function withTimeout(baseFetch: BaseFetch, timeout: number): BaseFetch {
       controller.abort();
       cleanup();
     }, timeout);
+    // Node-only: browser timers are numbers with no `unref`. Without this,
+    // an unread response body holds the event loop open for the full
+    // timeout even though the request already finished.
+    if (typeof timer === 'object' && 'unref' in timer) timer.unref();
 
     // LibraryError specifically: RpcChannel#errorHandler re-throws anything
     // else as a bare `Error(message)`, which would drop `code`.

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -13,7 +13,7 @@ type ProviderInstance = StaticJsonRpcProvider | RpcProvider;
 export type ProviderType = 'evm' | 'starknet';
 
 const DEFAULT_BROVIDER_URL = 'https://rpc.snapshot.org' as const;
-const DEFAULT_TIMEOUT = 25000 as const;
+export const DEFAULT_TIMEOUT = 25000 as const;
 
 const providerMemo = new Map<string, ProviderInstance>();
 

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -1,5 +1,6 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
-import { RpcProvider } from 'starknet';
+import crossFetch from 'cross-fetch';
+import { LibraryError, RpcProvider, RpcProviderOptions } from 'starknet';
 import networks from '../networks.json';
 
 export interface ProviderOptions {
@@ -87,11 +88,56 @@ function getEvmProvider(
   );
 }
 
+type BaseFetch = NonNullable<RpcProviderOptions['baseFetch']>;
+
+// starknet.js v6 has no timeout option, and its RpcChannel calls `baseFetch`
+// with no signal of its own, so bounding the fetch is the only way to bound a
+// request. Without this a node that accepts the connection but never answers
+// hangs until the runtime's own ceiling (~300s on undici), and a hang is not
+// contained by a caller's try/catch the way a throw is.
+//
+// AbortController + setTimeout rather than `AbortSignal.timeout`, which needs
+// Safari 16 / Firefox 100: this is what the `fetch` helper in ../utils already
+// does, so the browser bundle keeps the floor it has today. That helper cannot
+// be reused here, ../utils imports this module.
+export function withTimeout(baseFetch: BaseFetch, timeout: number): BaseFetch {
+  if (timeout <= 0) return baseFetch;
+
+  return async (url, init) => {
+    const controller = new AbortController();
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, timeout);
+
+    try {
+      return await baseFetch(url, { ...init, signal: controller.signal });
+    } catch (e) {
+      if (!timedOut) throw e;
+
+      // RpcChannel#errorHandler re-throws anything that is not a LibraryError
+      // as a bare `Error(message)`, which drops own properties, so `code` only
+      // survives on a LibraryError. `TIMEOUT` is the code ethers puts on the
+      // EVM provider's timeout, so both providers now fail the same way.
+      throw Object.assign(
+        new LibraryError(`Request timeout after ${timeout}ms`),
+        {
+          code: 'TIMEOUT'
+        }
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}
+
 function getStarknetProvider(
   networkKey: string,
   options: Required<ProviderOptions>
 ): RpcProvider {
   return new RpcProvider({
-    nodeUrl: `${options.broviderUrl}/${networkKey}`
+    nodeUrl: `${options.broviderUrl}/${networkKey}`,
+    baseFetch: withTimeout(crossFetch, options.timeout)
   });
 }

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -36,7 +36,9 @@ export function normalizeOptions(
     // `setTimeout(..., NaN)` fires on the next tick, aborting every request.
     timeout:
       typeof timeout === 'number' && Number.isFinite(timeout) && timeout >= 0
-        ? timeout
+        ? // setTimeout's delay is a 32-bit signed int; above this Node
+          // silently clamps it to ~1ms instead of the requested duration.
+          Math.min(timeout, 2_147_483_647)
         : DEFAULT_TIMEOUT
   };
 }

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -1,5 +1,4 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
-import crossFetch from 'cross-fetch';
 import { LibraryError, RpcProvider, RpcProviderOptions } from 'starknet';
 import networks from '../networks.json';
 
@@ -146,8 +145,8 @@ export function withTimeout(baseFetch: BaseFetch, timeout: number): BaseFetch {
       throw timedOut ? timeoutError() : e;
     }
 
-    // Resolving only means the headers arrived, and node-fetch bounds neither
-    // the body stream nor the parse. Hold the deadline over RpcChannel's read.
+    // Resolving only means the headers arrived; nothing bounds the body stream
+    // or the parse that follow. Hold the deadline over RpcChannel's read.
     const json = response.json.bind(response);
     response.json = async () => {
       try {
@@ -170,8 +169,14 @@ function getStarknetProvider(
   return new RpcProvider({
     nodeUrl: `${options.broviderUrl}/${networkKey}`,
     // At 0 there is no deadline to add, so leave starknet its own transport
-    // (`baseFetch ?? ponyfill`) rather than swap in crossFetch for nothing.
+    // (`baseFetch ?? ponyfill`) rather than swap the transport for nothing.
+    // Native `fetch`, bound like starknet's own browser default: the package
+    // floor has it everywhere (Node >= 18, evergreen browsers), and
+    // cross-fetch would downgrade it — node-fetch 2 on Node (losing
+    // connection reuse), an XHR ponyfill in the bundled browser build.
     baseFetch:
-      options.timeout > 0 ? withTimeout(crossFetch, options.timeout) : undefined
+      options.timeout > 0
+        ? withTimeout(fetch.bind(globalThis), options.timeout)
+        : undefined
   });
 }

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -111,6 +111,15 @@ export function withTimeout(baseFetch: BaseFetch, timeout: number): BaseFetch {
       controller.abort();
     }, timeout);
 
+    // Compose with a caller's signal rather than replacing it, so an abort from
+    // above still cancels the request at once and arrives with its own reason
+    // instead of being held until the timeout. An engine that predates
+    // `abort(reason)` ignores the argument and still aborts.
+    const callerSignal = init?.signal;
+    const abortFromCaller = () => controller.abort(callerSignal?.reason);
+    if (callerSignal?.aborted) abortFromCaller();
+    else callerSignal?.addEventListener('abort', abortFromCaller);
+
     try {
       return await baseFetch(url, { ...init, signal: controller.signal });
     } catch (e) {
@@ -128,6 +137,7 @@ export function withTimeout(baseFetch: BaseFetch, timeout: number): BaseFetch {
       );
     } finally {
       clearTimeout(timer);
+      callerSignal?.removeEventListener('abort', abortFromCaller);
     }
   };
 }

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -28,9 +28,17 @@ const providerFnMap: Record<
 export function normalizeOptions(
   options: ProviderOptions = {}
 ): Required<ProviderOptions> {
+  const { timeout } = options;
+
   return {
     broviderUrl: options.broviderUrl || DEFAULT_BROVIDER_URL,
-    timeout: options.timeout ?? DEFAULT_TIMEOUT
+    // Not `??`: it passes `NaN` through (`Number()` of an unset env var), and
+    // `setTimeout(..., NaN)` fires on the next tick, aborting every request.
+    // Here rather than in `withTimeout`: ethers needs the same normalization.
+    timeout:
+      typeof timeout === 'number' && Number.isFinite(timeout) && timeout >= 0
+        ? timeout
+        : DEFAULT_TIMEOUT
   };
 }
 

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -34,7 +34,6 @@ export function normalizeOptions(
     broviderUrl: options.broviderUrl || DEFAULT_BROVIDER_URL,
     // Not `??`: it passes `NaN` through (`Number()` of an unset env var), and
     // `setTimeout(..., NaN)` fires on the next tick, aborting every request.
-    // Here rather than in `withTimeout`: ethers needs the same normalization.
     timeout:
       typeof timeout === 'number' && Number.isFinite(timeout) && timeout >= 0
         ? timeout
@@ -141,9 +140,8 @@ export function withTimeout(baseFetch: BaseFetch, timeout: number): BaseFetch {
       throw timedOut ? timeoutError() : e;
     }
 
-    // Resolving only means the headers arrived: RpcChannel reads the body
-    // afterwards with its own `.json()`, and node-fetch bounds neither the
-    // body stream nor the parse. Hold the deadline until that settles.
+    // Resolving only means the headers arrived, and node-fetch bounds neither
+    // the body stream nor the parse. Hold the deadline over RpcChannel's read.
     const json = response.json.bind(response);
     response.json = async () => {
       try {
@@ -165,9 +163,8 @@ function getStarknetProvider(
 ): RpcProvider {
   return new RpcProvider({
     nodeUrl: `${options.broviderUrl}/${networkKey}`,
-    // `undefined` leaves starknet its own transport (`baseFetch ?? ponyfill`):
-    // with no timeout to add, swapping in crossFetch would only cost the
-    // caller a transport and the ceiling that comes with the stock one.
+    // At 0 there is no deadline to add, so leave starknet its own transport
+    // (`baseFetch ?? ponyfill`) rather than swap in crossFetch for nothing.
     baseFetch:
       options.timeout > 0 ? withTimeout(crossFetch, options.timeout) : undefined
   });

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -98,34 +98,54 @@ export function withTimeout(baseFetch: BaseFetch, timeout: number): BaseFetch {
 
   return async (url, init) => {
     const controller = new AbortController();
+    const callerSignal = init?.signal;
+    const abortFromCaller = () => controller.abort(callerSignal?.reason);
     let timedOut = false;
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      callerSignal?.removeEventListener('abort', abortFromCaller);
+    };
+    // Cleans up after itself: nothing else will if the body is never read.
     const timer = setTimeout(() => {
       timedOut = true;
       controller.abort();
+      cleanup();
     }, timeout);
 
-    const callerSignal = init?.signal;
-    const abortFromCaller = () => controller.abort(callerSignal?.reason);
+    // LibraryError specifically: RpcChannel#errorHandler re-throws anything
+    // else as a bare `Error(message)`, which would drop `code`.
+    const timeoutError = () =>
+      Object.assign(new LibraryError(`Request timeout after ${timeout}ms`), {
+        code: 'TIMEOUT'
+      });
+
     if (callerSignal?.aborted) abortFromCaller();
     else callerSignal?.addEventListener('abort', abortFromCaller);
 
+    let response: Response;
     try {
-      return await baseFetch(url, { ...init, signal: controller.signal });
+      response = await baseFetch(url, { ...init, signal: controller.signal });
     } catch (e) {
-      if (!timedOut) throw e;
-
-      // LibraryError specifically: RpcChannel#errorHandler re-throws anything
-      // else as a bare `Error(message)`, which would drop `code`.
-      throw Object.assign(
-        new LibraryError(`Request timeout after ${timeout}ms`),
-        {
-          code: 'TIMEOUT'
-        }
-      );
-    } finally {
-      clearTimeout(timer);
-      callerSignal?.removeEventListener('abort', abortFromCaller);
+      cleanup();
+      throw timedOut ? timeoutError() : e;
     }
+
+    // Resolving only means the headers arrived: RpcChannel reads the body
+    // afterwards with its own `.json()`, and node-fetch bounds neither the
+    // body stream nor the parse. Hold the deadline until that settles.
+    const json = response.json.bind(response);
+    response.json = async () => {
+      try {
+        return await json();
+      } catch (e) {
+        throw timedOut ? timeoutError() : e;
+      } finally {
+        cleanup();
+      }
+    };
+
+    return response;
   };
 }
 

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -90,17 +90,10 @@ function getEvmProvider(
 
 type BaseFetch = NonNullable<RpcProviderOptions['baseFetch']>;
 
-// starknet.js v6 has no timeout option, and its RpcChannel calls `baseFetch`
-// with no signal of its own, so bounding the fetch is the only way to bound a
-// request. Without this a node that accepts the connection but never answers
-// hangs until the runtime's own ceiling (~300s on undici), and a hang is not
-// contained by a caller's try/catch the way a throw is.
-//
-// AbortController + setTimeout rather than `AbortSignal.timeout`, which needs
-// Safari 16 / Firefox 100: this is what the `fetch` helper in ../utils already
-// does, so the browser bundle keeps the floor it has today. That helper cannot
-// be reused here, ../utils imports this module.
+// Not `AbortSignal.timeout`: it would raise the browser bundle's floor to
+// Safari 16.
 export function withTimeout(baseFetch: BaseFetch, timeout: number): BaseFetch {
+  // Without this, `setTimeout(..., 0)` aborts every request on the next tick.
   if (timeout <= 0) return baseFetch;
 
   return async (url, init) => {
@@ -111,10 +104,6 @@ export function withTimeout(baseFetch: BaseFetch, timeout: number): BaseFetch {
       controller.abort();
     }, timeout);
 
-    // Compose with a caller's signal rather than replacing it, so an abort from
-    // above still cancels the request at once and arrives with its own reason
-    // instead of being held until the timeout. An engine that predates
-    // `abort(reason)` ignores the argument and still aborts.
     const callerSignal = init?.signal;
     const abortFromCaller = () => controller.abort(callerSignal?.reason);
     if (callerSignal?.aborted) abortFromCaller();
@@ -125,10 +114,8 @@ export function withTimeout(baseFetch: BaseFetch, timeout: number): BaseFetch {
     } catch (e) {
       if (!timedOut) throw e;
 
-      // RpcChannel#errorHandler re-throws anything that is not a LibraryError
-      // as a bare `Error(message)`, which drops own properties, so `code` only
-      // survives on a LibraryError. `TIMEOUT` is the code ethers puts on the
-      // EVM provider's timeout, so both providers now fail the same way.
+      // LibraryError specifically: RpcChannel#errorHandler re-throws anything
+      // else as a bare `Error(message)`, which would drop `code`.
       throw Object.assign(
         new LibraryError(`Request timeout after ${timeout}ms`),
         {

--- a/test/integration/utils/fetch.spec.ts
+++ b/test/integration/utils/fetch.spec.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 import { AddressInfo, createServer, Server, Socket } from 'net';
-import { withTimeout } from '../../../src/utils/fetch';
+import { BODY_READERS, withTimeout } from '../../../src/utils/fetch';
 
 describe('withTimeout()', () => {
   // A fresh one per test: the deadline clears when the body is read, so these
@@ -121,7 +121,7 @@ describe('withTimeout()', () => {
   // The primitive advertises a plain `FetchLike`, so a caller is free to read
   // the body with any of these; the deadline and the error have to be the same
   // whichever one it picks.
-  test.each(['json', 'text', 'arrayBuffer', 'blob', 'formData'])(
+  test.each(BODY_READERS)(
     'maps the timeout for a caller reading the body with .%s()',
     async (reader) => {
       const timeoutError = () =>

--- a/test/integration/utils/fetch.spec.ts
+++ b/test/integration/utils/fetch.spec.ts
@@ -222,7 +222,15 @@ describe('withTimeout() over a real socket', () => {
   let url: string;
 
   beforeAll(async () => {
-    server = createServer((socket) => sockets.push(socket));
+    // A caller abort ends the request mid-flight, so an RST is expected; an
+    // unhandled 'error' on a socket takes the worker down rather than
+    // failing a test.
+    server = createServer((socket) => {
+      socket.on('error', () => {
+        /* expected */
+      });
+      sockets.push(socket);
+    });
     await new Promise<void>((resolve) =>
       server.listen(0, '127.0.0.1', () => resolve())
     );

--- a/test/integration/utils/fetch.spec.ts
+++ b/test/integration/utils/fetch.spec.ts
@@ -16,18 +16,21 @@ describe('withTimeout()', () => {
       });
     });
 
-  // Stands in for node-fetch, whose body stream errors on the abort.
-  const stallingBodyFetch = () =>
-    vi.fn((_url: any, init: RequestInit = {}) =>
-      Promise.resolve({
-        json: () =>
-          new Promise((_resolve, reject) =>
-            init.signal?.addEventListener('abort', () =>
-              reject(init.signal?.reason)
-            )
+  // Stands in for a real transport, whose body stream errors on the abort.
+  const stallingBodyFetch = (readers = ['json']) =>
+    vi.fn((_url: any, init: RequestInit = {}) => {
+      const stall = () =>
+        new Promise((_resolve, reject) =>
+          init.signal?.addEventListener('abort', () =>
+            reject(init.signal?.reason)
           )
-      } as unknown as Response)
-    );
+        );
+      return Promise.resolve(
+        Object.fromEntries(
+          readers.map((name) => [name, stall])
+        ) as unknown as Response
+      );
+    });
 
   test('calls the wrapped fetch and preserves its init', async () => {
     const response = jsonResponse();
@@ -113,6 +116,37 @@ describe('withTimeout()', () => {
       message: 'gone',
       code: 'TIMEOUT'
     });
+  });
+
+  // The primitive advertises a plain `FetchLike`, so a caller is free to read
+  // the body with any of these; the deadline and the error have to be the same
+  // whichever one it picks.
+  test.each(['json', 'text', 'arrayBuffer', 'blob', 'formData'])(
+    'maps the timeout for a caller reading the body with .%s()',
+    async (reader) => {
+      const timeoutError = () =>
+        Object.assign(new Error('gone'), { code: 'TIMEOUT' });
+      const response = await withTimeout(stallingBodyFetch([reader]), 50, {
+        timeoutError
+      })('https://rpc.test', {});
+
+      await expect((response as any)[reader]()).rejects.toMatchObject({
+        message: 'gone',
+        code: 'TIMEOUT'
+      });
+    }
+  );
+
+  test('clears its timer for a caller reading the body with .text()', async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const baseFetch = vi.fn().mockResolvedValue(new Response('hello'));
+
+    const response = await withTimeout(baseFetch, 1000)('https://rpc.test', {});
+    expect(clearTimeoutSpy).not.toHaveBeenCalled();
+    await response.text();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
   });
 
   test('does not rewrite an error that is not its own timeout', async () => {
@@ -205,7 +239,10 @@ describe('withTimeout() over a real socket', () => {
     const start = Date.now();
 
     await expect(
-      withTimeout(fetch.bind(globalThis), 300)(url, { method: 'POST', body: '{}' })
+      withTimeout(fetch.bind(globalThis), 300)(url, {
+        method: 'POST',
+        body: '{}'
+      })
     ).rejects.toThrow('Request timeout after 300ms');
 
     const elapsed = Date.now() - start;

--- a/test/integration/utils/fetch.spec.ts
+++ b/test/integration/utils/fetch.spec.ts
@@ -118,6 +118,24 @@ describe('withTimeout()', () => {
     });
   });
 
+  // Derived from the runtime rather than from BODY_READERS, because the matrix
+  // below cannot see a reader the list forgot: `bytes` escaped the deadline
+  // that way. Everything on `Response.prototype` reads the body except these.
+  const NON_READERS = ['constructor', 'clone'];
+  const runtimeBodyReaders = Object.entries(
+    Object.getOwnPropertyDescriptors(Response.prototype)
+  )
+    .filter(
+      ([name, { value }]) =>
+        typeof value === 'function' && !NON_READERS.includes(name)
+    )
+    .map(([name]) => name);
+
+  test('covers every body reader the runtime exposes', () => {
+    expect(runtimeBodyReaders.length).toBeGreaterThan(0);
+    expect(BODY_READERS).toEqual(expect.arrayContaining(runtimeBodyReaders));
+  });
+
   // The primitive advertises a plain `FetchLike`, so a caller is free to read
   // the body with any of these; the deadline and the error have to be the same
   // whichever one it picks.

--- a/test/integration/utils/fetch.spec.ts
+++ b/test/integration/utils/fetch.spec.ts
@@ -1,0 +1,229 @@
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+import { AddressInfo, createServer, Server, Socket } from 'net';
+import { withTimeout } from '../../../src/utils/fetch';
+
+describe('withTimeout()', () => {
+  // A fresh one per test: the deadline clears when the body is read, so these
+  // tests consume it.
+  const jsonResponse = () => new Response('{}');
+
+  const signalRespectingFetch = () =>
+    vi.fn((_url: any, init: RequestInit = {}) => {
+      const { signal } = init;
+      return new Promise<Response>((_resolve, reject) => {
+        if (signal?.aborted) return reject(signal.reason);
+        signal?.addEventListener('abort', () => reject(signal.reason));
+      });
+    });
+
+  // Stands in for node-fetch, whose body stream errors on the abort.
+  const stallingBodyFetch = () =>
+    vi.fn((_url: any, init: RequestInit = {}) =>
+      Promise.resolve({
+        json: () =>
+          new Promise((_resolve, reject) =>
+            init.signal?.addEventListener('abort', () =>
+              reject(init.signal?.reason)
+            )
+          )
+      } as unknown as Response)
+    );
+
+  test('calls the wrapped fetch and preserves its init', async () => {
+    const response = jsonResponse();
+    const baseFetch = vi.fn().mockResolvedValue(response);
+    const init = { method: 'POST', body: '{}', headers: { a: 'b' } };
+
+    await expect(
+      withTimeout(baseFetch, 1000)('https://rpc.test', init)
+    ).resolves.toBe(response);
+    expect(baseFetch).toHaveBeenCalledWith(
+      'https://rpc.test',
+      expect.objectContaining({ ...init, signal: expect.any(AbortSignal) })
+    );
+  });
+
+  test('returns the wrapped fetch untouched when the timeout is disabled', () => {
+    const baseFetch = vi.fn();
+
+    expect(withTimeout(baseFetch, 0)).toBe(baseFetch);
+    expect(withTimeout(baseFetch, -1)).toBe(baseFetch);
+  });
+
+  test('clears its timer so a read request holds nothing open', async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const baseFetch = vi.fn().mockResolvedValue(jsonResponse());
+
+    const response = await withTimeout(baseFetch, 1000)('https://rpc.test', {});
+    expect(clearTimeoutSpy).not.toHaveBeenCalled();
+    await response.json();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+
+  test('unrefs its timer so an unread body holds nothing open', async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const baseFetch = vi.fn().mockResolvedValue(jsonResponse());
+
+    // Resolve the response and never read the body: cleanup() cannot run.
+    await withTimeout(baseFetch, 1000)('https://rpc.test', {});
+
+    expect(setTimeoutSpy.mock.results[0].value.hasRef()).toBe(false);
+    setTimeoutSpy.mockRestore();
+  });
+
+  test('rejects with a timeout error when the headers never arrive', async () => {
+    await expect(
+      withTimeout(signalRespectingFetch(), 50)('https://rpc.test', {})
+    ).rejects.toThrow('Request timeout after 50ms');
+  });
+
+  test('maps a timeout during the body read, not just the headers', async () => {
+    const response = await withTimeout(stallingBodyFetch(), 50)(
+      'https://rpc.test',
+      {}
+    );
+
+    await expect(response.json()).rejects.toThrow('Request timeout after 50ms');
+  });
+
+  test('builds the timeout error with the supplied factory', async () => {
+    const timeoutError = vi.fn(
+      (timeout: number) => new Error(`gone ${timeout}`)
+    );
+
+    await expect(
+      withTimeout(signalRespectingFetch(), 50, { timeoutError })(
+        'https://rpc.test',
+        {}
+      )
+    ).rejects.toThrow('gone 50');
+    expect(timeoutError).toHaveBeenCalledWith(50);
+  });
+
+  test('uses the supplied factory on the body read too', async () => {
+    const timeoutError = () =>
+      Object.assign(new Error('gone'), { code: 'TIMEOUT' });
+    const response = await withTimeout(stallingBodyFetch(), 50, {
+      timeoutError
+    })('https://rpc.test', {});
+
+    await expect(response.json()).rejects.toMatchObject({
+      message: 'gone',
+      code: 'TIMEOUT'
+    });
+  });
+
+  test('does not rewrite an error that is not its own timeout', async () => {
+    const baseFetch = vi.fn().mockRejectedValue(new Error('network down'));
+
+    await expect(
+      withTimeout(baseFetch, 1000)('https://rpc.test', {})
+    ).rejects.toThrow('network down');
+  });
+
+  test('rejects on a caller abort with the caller reason, not a timeout', async () => {
+    const caller = new AbortController();
+    const reason = new Error('caller gave up');
+    const request = withTimeout(signalRespectingFetch(), 30000)(
+      'https://rpc.test',
+      { signal: caller.signal }
+    );
+
+    caller.abort(reason);
+
+    await expect(request).rejects.toBe(reason);
+  });
+
+  test('aborts at once when the caller signal is already aborted', async () => {
+    const caller = new AbortController();
+    const reason = new Error('caller gave up first');
+    caller.abort(reason);
+
+    await expect(
+      withTimeout(signalRespectingFetch(), 30000)('https://rpc.test', {
+        signal: caller.signal
+      })
+    ).rejects.toBe(reason);
+  });
+
+  test('unhooks the caller signal when the deadline fires on an unread body', async () => {
+    const caller = new AbortController();
+    const removeEventListener = vi.spyOn(caller.signal, 'removeEventListener');
+
+    await withTimeout(stallingBodyFetch(), 20)('https://rpc.test', {
+      signal: caller.signal
+    });
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    expect(removeEventListener).toHaveBeenCalledWith(
+      'abort',
+      expect.any(Function)
+    );
+  });
+
+  test('stops listening on the caller signal once the request settles', async () => {
+    const caller = new AbortController();
+    const removeEventListener = vi.spyOn(caller.signal, 'removeEventListener');
+    const baseFetch = vi.fn().mockResolvedValue(jsonResponse());
+
+    const response = await withTimeout(baseFetch, 1000)('https://rpc.test', {
+      signal: caller.signal
+    });
+    await response.json();
+
+    expect(removeEventListener).toHaveBeenCalledWith(
+      'abort',
+      expect.any(Function)
+    );
+  });
+});
+
+describe('withTimeout() over a real socket', () => {
+  // Accepts the connection and never answers; a refused connection would fail
+  // fast on its own.
+  let server: Server;
+  let sockets: Socket[] = [];
+  let url: string;
+
+  beforeAll(async () => {
+    server = createServer((socket) => sockets.push(socket));
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', () => resolve())
+    );
+    url = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterAll(async () => {
+    sockets.forEach((socket) => socket.destroy());
+    sockets = [];
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  test('rejects a hung request instead of waiting on the runtime', async () => {
+    const start = Date.now();
+
+    await expect(
+      withTimeout(fetch.bind(globalThis), 300)(url, { method: 'POST', body: '{}' })
+    ).rejects.toThrow('Request timeout after 300ms');
+
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(300);
+    expect(elapsed).toBeLessThan(3000);
+  });
+
+  test('lets a caller abort cancel a hung request before the timeout', async () => {
+    const caller = new AbortController();
+    const start = Date.now();
+    const request = withTimeout(fetch.bind(globalThis), 5000)(url, {
+      method: 'POST',
+      body: '{}',
+      signal: caller.signal
+    });
+    setTimeout(() => caller.abort(), 50);
+
+    await expect(request).rejects.toMatchObject({ name: 'AbortError' });
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+});

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -306,6 +306,13 @@ describe('Starknet provider timeout', () => {
     expect(elapsed).toBeLessThan(3000);
   });
 
+  test('leaves starknet its own transport when the timeout is disabled', () => {
+    const provider = getProvider(STARKNET_NETWORK, { broviderUrl, timeout: 0 });
+    const stock = new RpcProvider({ nodeUrl: broviderUrl }) as any;
+
+    expect(provider.channel.baseFetch).toBe(stock.channel.baseFetch);
+  });
+
   test('rejects with the same error code as the EVM provider', async () => {
     const provider = getProvider(STARKNET_NETWORK, {
       broviderUrl,

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -358,23 +358,12 @@ describe('Starknet provider timeout', () => {
       broviderUrl,
       timeout: 400
     });
+    const request = provider.getSpecVersion();
 
-    await expect(provider.getSpecVersion()).rejects.toMatchObject({
-      code: 'TIMEOUT'
-    });
-  });
-
-  // A plain Error would come back out of RpcChannel#errorHandler stripped of
-  // `code`, so the class is what keeps the assertion above true.
-  test('rejects with a LibraryError, the only class that keeps the code', async () => {
-    const provider = getProvider(STARKNET_NETWORK, {
-      broviderUrl,
-      timeout: 400
-    });
-
-    await expect(provider.getSpecVersion()).rejects.toBeInstanceOf(
-      LibraryError
-    );
+    // A plain Error would come back out of RpcChannel#errorHandler stripped of
+    // `code`, so the class is what keeps the code assertion true.
+    await expect(request).rejects.toBeInstanceOf(LibraryError);
+    await expect(request).rejects.toMatchObject({ code: 'TIMEOUT' });
   });
 
   test('applies the default timeout when none is passed', async () => {

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -249,10 +249,19 @@ describe('Starknet provider timeout', () => {
   };
 
   beforeAll(async () => {
-    server = createServer((socket) => sockets.push(socket));
-    headersOnlyServer = createServer((socket) => {
+    // The deadline aborts mid-request, so an RST is expected; an unhandled
+    // 'error' on a socket takes the worker down rather than failing a test.
+    const accept = (socket: Socket) => {
+      socket.on('error', () => {
+        /* expected */
+      });
       sockets.push(socket);
-      socket.on('data', () =>
+      return socket;
+    };
+
+    server = createServer(accept);
+    headersOnlyServer = createServer((socket) => {
+      accept(socket).on('data', () =>
         socket.write(
           'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 24\r\n\r\n'
         )

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -2,11 +2,10 @@ import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 import { AddressInfo, createServer, Server, Socket } from 'net';
 import getProvider, {
   DEFAULT_TIMEOUT,
-  normalizeOptions,
-  withTimeout
+  normalizeOptions
 } from '../../../src/utils/provider';
 import { getViemClient } from '../../../src/utils/viem';
-import { RpcProvider } from 'starknet';
+import { LibraryError, RpcProvider } from 'starknet';
 
 const STARKNET_NETWORK = '0x534e5f4d41494e';
 
@@ -356,18 +355,17 @@ describe('Starknet provider timeout', () => {
     });
   });
 
-  test('lets a caller abort cancel a hung request before the timeout', async () => {
-    const caller = new AbortController();
-    const start = Date.now();
-    const request = withTimeout(fetch.bind(globalThis), 5000)(broviderUrl, {
-      method: 'POST',
-      body: '{}',
-      signal: caller.signal
+  // A plain Error would come back out of RpcChannel#errorHandler stripped of
+  // `code`, so the class is what keeps the assertion above true.
+  test('rejects with a LibraryError, the only class that keeps the code', async () => {
+    const provider = getProvider(STARKNET_NETWORK, {
+      broviderUrl,
+      timeout: 400
     });
-    setTimeout(() => caller.abort(), 50);
 
-    await expect(request).rejects.toMatchObject({ name: 'AbortError' });
-    expect(Date.now() - start).toBeLessThan(1000);
+    await expect(provider.getSpecVersion()).rejects.toBeInstanceOf(
+      LibraryError
+    );
   });
 
   test('applies the default timeout when none is passed', async () => {
@@ -384,133 +382,6 @@ describe('Starknet provider timeout', () => {
     } finally {
       vi.useRealTimers();
     }
-  });
-});
-
-describe('withTimeout()', () => {
-  // A factory, not a shared const: reading the body clears the deadline.
-  const jsonResponse = () => new Response('{}');
-
-  test('calls the wrapped fetch and preserves its init', async () => {
-    const response = jsonResponse();
-    const baseFetch = vi.fn().mockResolvedValue(response);
-    const init = { method: 'POST', body: '{}', headers: { a: 'b' } };
-
-    await expect(
-      withTimeout(baseFetch, 1000)('https://rpc.test', init)
-    ).resolves.toBe(response);
-    expect(baseFetch).toHaveBeenCalledWith(
-      'https://rpc.test',
-      expect.objectContaining({ ...init, signal: expect.any(AbortSignal) })
-    );
-  });
-
-  test('returns the wrapped fetch untouched when the timeout is disabled', () => {
-    const baseFetch = vi.fn();
-
-    expect(withTimeout(baseFetch, 0)).toBe(baseFetch);
-  });
-
-  test('clears its timer so a read request holds nothing open', async () => {
-    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
-    const baseFetch = vi.fn().mockResolvedValue(jsonResponse());
-
-    const response = await withTimeout(baseFetch, 1000)('https://rpc.test', {});
-    expect(clearTimeoutSpy).not.toHaveBeenCalled();
-    await response.json();
-
-    expect(clearTimeoutSpy).toHaveBeenCalled();
-    clearTimeoutSpy.mockRestore();
-  });
-
-  test('unrefs its timer so an unread body holds nothing open', async () => {
-    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
-    const baseFetch = vi.fn().mockResolvedValue(jsonResponse());
-
-    // Resolve the response and never read the body: cleanup() cannot run.
-    await withTimeout(baseFetch, 1000)('https://rpc.test', {});
-
-    expect(setTimeoutSpy.mock.results[0].value.hasRef()).toBe(false);
-    setTimeoutSpy.mockRestore();
-  });
-
-  test('maps a timeout during the body read, not just the headers', async () => {
-    // Stands in for node-fetch, whose body stream errors on the abort.
-    const baseFetch = vi.fn((_url: any, init: RequestInit = {}) =>
-      Promise.resolve({
-        json: () =>
-          new Promise((_resolve, reject) =>
-            init.signal?.addEventListener('abort', () =>
-              reject(init.signal?.reason)
-            )
-          )
-      } as unknown as Response)
-    );
-
-    const response = await withTimeout(baseFetch, 50)('https://rpc.test', {});
-
-    await expect(response.json()).rejects.toMatchObject({
-      message: 'Request timeout after 50ms',
-      code: 'TIMEOUT'
-    });
-  });
-
-  test('does not rewrite an error that is not its own timeout', async () => {
-    const baseFetch = vi.fn().mockRejectedValue(new Error('network down'));
-
-    await expect(
-      withTimeout(baseFetch, 1000)('https://rpc.test', {})
-    ).rejects.toThrow('network down');
-  });
-
-  const signalRespectingFetch = () =>
-    vi.fn((_url: any, init: RequestInit = {}) => {
-      const { signal } = init;
-      return new Promise<Response>((_resolve, reject) => {
-        if (signal?.aborted) return reject(signal.reason);
-        signal?.addEventListener('abort', () => reject(signal.reason));
-      });
-    });
-
-  test('rejects on a caller abort with the caller reason, not a timeout', async () => {
-    const caller = new AbortController();
-    const reason = new Error('caller gave up');
-    const request = withTimeout(signalRespectingFetch(), 30000)(
-      'https://rpc.test',
-      { signal: caller.signal }
-    );
-
-    caller.abort(reason);
-
-    await expect(request).rejects.toBe(reason);
-  });
-
-  test('aborts at once when the caller signal is already aborted', async () => {
-    const caller = new AbortController();
-    const reason = new Error('caller gave up first');
-    caller.abort(reason);
-
-    await expect(
-      withTimeout(signalRespectingFetch(), 30000)('https://rpc.test', {
-        signal: caller.signal
-      })
-    ).rejects.toBe(reason);
-  });
-
-  test('stops listening on the caller signal once the request settles', async () => {
-    const caller = new AbortController();
-    const removeEventListener = vi.spyOn(caller.signal, 'removeEventListener');
-    const baseFetch = vi.fn().mockResolvedValue(jsonResponse());
-
-    const response = await withTimeout(baseFetch, 1000)('https://rpc.test', {
-      signal: caller.signal
-    });
-    await response.json();
-
-    expect(removeEventListener).toHaveBeenCalledWith(
-      'abort',
-      expect.any(Function)
-    );
   });
 });
 

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -479,7 +479,10 @@ describe('normalizeOptions()', () => {
     [Infinity, DEFAULT_TIMEOUT],
     [-100, DEFAULT_TIMEOUT],
     [0, 0],
-    [30000, 30000]
+    [30000, 30000],
+    // Above this Node clamps the setTimeout delay to ~1ms.
+    [2_147_483_648, 2_147_483_647],
+    [3e9, 2_147_483_647]
   ])('normalizes a timeout of %s to %s', (timeout, expected) => {
     expect(normalizeOptions({ timeout }).timeout).toBe(expected);
   });

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -1,7 +1,10 @@
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 import { AddressInfo, createServer, Server, Socket } from 'net';
 import crossFetch from 'cross-fetch';
-import getProvider, { withTimeout } from '../../../src/utils/provider';
+import getProvider, {
+  normalizeOptions,
+  withTimeout
+} from '../../../src/utils/provider';
 import { getViemClient } from '../../../src/utils/viem';
 import { RpcProvider } from 'starknet';
 
@@ -469,5 +472,18 @@ describe('withTimeout()', () => {
       'abort',
       expect.any(Function)
     );
+  });
+});
+
+describe('normalizeOptions()', () => {
+  test.each([
+    [undefined, DEFAULT_TIMEOUT],
+    [NaN, DEFAULT_TIMEOUT],
+    [Infinity, DEFAULT_TIMEOUT],
+    [-100, DEFAULT_TIMEOUT],
+    [0, 0],
+    [30000, 30000]
+  ])('normalizes a timeout of %s to %s', (timeout, expected) => {
+    expect(normalizeOptions({ timeout }).timeout).toBe(expected);
   });
 });

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 import { AddressInfo, createServer, Server, Socket } from 'net';
 import crossFetch from 'cross-fetch';
 import getProvider, {
+  DEFAULT_TIMEOUT,
   normalizeOptions,
   withTimeout
 } from '../../../src/utils/provider';
@@ -9,7 +10,6 @@ import { getViemClient } from '../../../src/utils/viem';
 import { RpcProvider } from 'starknet';
 
 const STARKNET_NETWORK = '0x534e5f4d41494e';
-const DEFAULT_TIMEOUT = 25000;
 
 describe('test providers', () => {
   describe('getProvider()', () => {

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -1,6 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 import { AddressInfo, createServer, Server, Socket } from 'net';
-import crossFetch from 'cross-fetch';
 import getProvider, {
   DEFAULT_TIMEOUT,
   normalizeOptions,
@@ -314,6 +313,38 @@ describe('Starknet provider timeout', () => {
     expect(provider.channel.baseFetch).toBe(stock.channel.baseFetch);
   });
 
+  // cross-fetch's Node entry is node-fetch 2, which sets `Connection: close`
+  // whenever no agent is passed, so it reuses no connection to the brovider.
+  test('does not close the connection after every request', async () => {
+    const requests: string[] = [];
+    const open: Socket[] = [];
+    const rpcServer = createServer((socket) => {
+      open.push(socket);
+      socket.on('data', (chunk) => {
+        requests.push(chunk.toString());
+        const body = '{"jsonrpc":"2.0","id":1,"result":"0.8.1"}';
+        socket.write(
+          'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n' +
+            `Content-Length: ${Buffer.byteLength(body)}\r\n\r\n${body}`
+        );
+      });
+    });
+    const rpcUrl = await listen(rpcServer);
+
+    try {
+      const provider = getProvider(STARKNET_NETWORK, {
+        broviderUrl: rpcUrl,
+        timeout: 1000
+      });
+
+      await expect(provider.getSpecVersion()).resolves.toBe('0.8.1');
+      expect(requests.join('')).not.toMatch(/^connection:\s*close/im);
+    } finally {
+      open.forEach((socket) => socket.destroy());
+      await new Promise<void>((resolve) => rpcServer.close(() => resolve()));
+    }
+  });
+
   test('rejects with the same error code as the EVM provider', async () => {
     const provider = getProvider(STARKNET_NETWORK, {
       broviderUrl,
@@ -328,7 +359,7 @@ describe('Starknet provider timeout', () => {
   test('lets a caller abort cancel a hung request before the timeout', async () => {
     const caller = new AbortController();
     const start = Date.now();
-    const request = withTimeout(crossFetch, 5000)(broviderUrl, {
+    const request = withTimeout(fetch.bind(globalThis), 5000)(broviderUrl, {
       method: 'POST',
       body: '{}',
       signal: caller.signal

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -392,6 +392,17 @@ describe('withTimeout()', () => {
     clearTimeoutSpy.mockRestore();
   });
 
+  test('unrefs its timer so an unread body holds nothing open', async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const baseFetch = vi.fn().mockResolvedValue(jsonResponse());
+
+    // Resolve the response and never read the body: cleanup() cannot run.
+    await withTimeout(baseFetch, 1000)('https://rpc.test', {});
+
+    expect(setTimeoutSpy.mock.results[0].value.hasRef()).toBe(false);
+    setTimeoutSpy.mockRestore();
+  });
+
   test('maps a timeout during the body read, not just the headers', async () => {
     // Stands in for node-fetch, whose body stream errors on the abort.
     const baseFetch = vi.fn((_url: any, init: RequestInit = {}) =>

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -235,11 +235,9 @@ describe('test providers', () => {
 });
 
 describe('Starknet provider timeout', () => {
-  // Accepts the connection and never answers; a refused connection would fail
-  // fast on its own.
+  // Not a refused connection: that one fails fast on its own.
   let server: Server;
-  // Answers with complete headers and then never sends the body, the way a
-  // hung proxy that has already relayed upstream headers does.
+  // A proxy that wedges after it has relayed the upstream headers.
   let headersOnlyServer: Server;
   let sockets: Socket[] = [];
   let broviderUrl: string;
@@ -359,8 +357,7 @@ describe('Starknet provider timeout', () => {
 });
 
 describe('withTimeout()', () => {
-  // A fresh one per test: the deadline now clears when the body is read, so
-  // these tests consume it.
+  // A factory, not a shared const: reading the body clears the deadline.
   const jsonResponse = () => new Response('{}');
 
   test('calls the wrapped fetch and preserves its init', async () => {

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -1,7 +1,11 @@
-import { describe, expect, test } from 'vitest';
-import getProvider from '../../../src/utils/provider';
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+import { AddressInfo, createServer, Server, Socket } from 'net';
+import getProvider, { withTimeout } from '../../../src/utils/provider';
 import { getViemClient } from '../../../src/utils/viem';
 import { RpcProvider } from 'starknet';
+
+const STARKNET_NETWORK = '0x534e5f4d41494e';
+const DEFAULT_TIMEOUT = 25000;
 
 describe('test providers', () => {
   describe('getProvider()', () => {
@@ -223,5 +227,114 @@ describe('test providers', () => {
       expect(provider1.connection.timeout).toBe(15000);
       expect(provider1.connection.url).toContain('custom.snapshot.org');
     });
+  });
+});
+
+describe('Starknet provider timeout', () => {
+  // Accepts the connection and then never answers. This is the failure mode
+  // that matters: a refused connection fails fast on its own, a hung node does
+  // not, and starknet.js has no timeout of its own to fall back on.
+  let server: Server;
+  let sockets: Socket[] = [];
+  let broviderUrl: string;
+
+  beforeAll(async () => {
+    server = createServer((socket) => sockets.push(socket));
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', () => resolve())
+    );
+    broviderUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterAll(async () => {
+    sockets.forEach((socket) => socket.destroy());
+    sockets = [];
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  test('rejects a hung request instead of hanging', async () => {
+    const provider = getProvider(STARKNET_NETWORK, {
+      broviderUrl,
+      timeout: 300
+    });
+    const start = Date.now();
+
+    await expect(provider.getSpecVersion()).rejects.toThrow(
+      'Request timeout after 300ms'
+    );
+
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(300);
+    expect(elapsed).toBeLessThan(3000);
+  });
+
+  test('rejects with the same error code as the EVM provider', async () => {
+    const provider = getProvider(STARKNET_NETWORK, {
+      broviderUrl,
+      timeout: 400
+    });
+
+    await expect(provider.getSpecVersion()).rejects.toMatchObject({
+      code: 'TIMEOUT'
+    });
+  });
+
+  test('applies the default timeout when none is passed', async () => {
+    // Fake only the timers this uses, so the pending socket is untouched and
+    // the suite does not sit here for the full 25s.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+
+    try {
+      const provider = getProvider(STARKNET_NETWORK, { broviderUrl });
+      const assertion = expect(provider.getSpecVersion()).rejects.toThrow(
+        `Request timeout after ${DEFAULT_TIMEOUT}ms`
+      );
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_TIMEOUT);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('withTimeout()', () => {
+  const response = new Response('{}');
+
+  test('calls the wrapped fetch and preserves its init', async () => {
+    const baseFetch = vi.fn().mockResolvedValue(response);
+    const init = { method: 'POST', body: '{}', headers: { a: 'b' } };
+
+    await expect(
+      withTimeout(baseFetch, 1000)('https://rpc.test', init)
+    ).resolves.toBe(response);
+    expect(baseFetch).toHaveBeenCalledWith(
+      'https://rpc.test',
+      expect.objectContaining({ ...init, signal: expect.any(AbortSignal) })
+    );
+  });
+
+  test('returns the wrapped fetch untouched when the timeout is disabled', () => {
+    const baseFetch = vi.fn();
+
+    expect(withTimeout(baseFetch, 0)).toBe(baseFetch);
+  });
+
+  test('clears its timer so a resolved request holds nothing open', async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const baseFetch = vi.fn().mockResolvedValue(response);
+
+    await withTimeout(baseFetch, 1000)('https://rpc.test', {});
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+
+  test('does not rewrite an error that is not its own timeout', async () => {
+    const baseFetch = vi.fn().mockRejectedValue(new Error('network down'));
+
+    await expect(
+      withTimeout(baseFetch, 1000)('https://rpc.test', {})
+    ).rejects.toThrow('network down');
   });
 });

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -232,9 +232,8 @@ describe('test providers', () => {
 });
 
 describe('Starknet provider timeout', () => {
-  // Accepts the connection and then never answers. This is the failure mode
-  // that matters: a refused connection fails fast on its own, a hung node does
-  // not, and starknet.js has no timeout of its own to fall back on.
+  // Accepts the connection and never answers; a refused connection would fail
+  // fast on its own.
   let server: Server;
   let sockets: Socket[] = [];
   let broviderUrl: string;
@@ -281,8 +280,6 @@ describe('Starknet provider timeout', () => {
   });
 
   test('lets a caller abort cancel a hung request before the timeout', async () => {
-    // The fetch we actually ship, against the same hung node: an abort from
-    // above has to reach the socket rather than sit behind the 5s timeout.
     const caller = new AbortController();
     const start = Date.now();
     const request = withTimeout(crossFetch, 5000)(broviderUrl, {
@@ -297,8 +294,6 @@ describe('Starknet provider timeout', () => {
   });
 
   test('applies the default timeout when none is passed', async () => {
-    // Fake only the timers this uses, so the pending socket is untouched and
-    // the suite does not sit here for the full 25s.
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
 
     try {
@@ -355,9 +350,6 @@ describe('withTimeout()', () => {
     ).rejects.toThrow('network down');
   });
 
-  // A fetch that settles only on an abort of the signal it was handed, up front
-  // or later, as a real fetch does. These fail if the caller's signal is
-  // dropped instead of composed.
   const signalRespectingFetch = () =>
     vi.fn((_url: any, init: RequestInit = {}) => {
       const { signal } = init;

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -235,21 +235,42 @@ describe('Starknet provider timeout', () => {
   // Accepts the connection and never answers; a refused connection would fail
   // fast on its own.
   let server: Server;
+  // Answers with complete headers and then never sends the body, the way a
+  // hung proxy that has already relayed upstream headers does.
+  let headersOnlyServer: Server;
   let sockets: Socket[] = [];
   let broviderUrl: string;
+  let headersOnlyUrl: string;
 
-  beforeAll(async () => {
-    server = createServer((socket) => sockets.push(socket));
+  const listen = async (server: Server): Promise<string> => {
     await new Promise<void>((resolve) =>
       server.listen(0, '127.0.0.1', () => resolve())
     );
-    broviderUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+    return `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  };
+
+  beforeAll(async () => {
+    server = createServer((socket) => sockets.push(socket));
+    headersOnlyServer = createServer((socket) => {
+      sockets.push(socket);
+      socket.on('data', () =>
+        socket.write(
+          'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 24\r\n\r\n'
+        )
+      );
+    });
+    broviderUrl = await listen(server);
+    headersOnlyUrl = await listen(headersOnlyServer);
   });
 
   afterAll(async () => {
     sockets.forEach((socket) => socket.destroy());
     sockets = [];
-    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await Promise.all(
+      [server, headersOnlyServer].map(
+        (s) => new Promise<void>((resolve) => s.close(() => resolve()))
+      )
+    );
   });
 
   test('rejects a hung request instead of hanging', async () => {
@@ -262,6 +283,23 @@ describe('Starknet provider timeout', () => {
     await expect(provider.getSpecVersion()).rejects.toThrow(
       'Request timeout after 300ms'
     );
+
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(300);
+    expect(elapsed).toBeLessThan(3000);
+  });
+
+  test('rejects when the body stalls after the headers arrive', async () => {
+    const provider = getProvider(STARKNET_NETWORK, {
+      broviderUrl: headersOnlyUrl,
+      timeout: 300
+    });
+    const start = Date.now();
+
+    await expect(provider.getSpecVersion()).rejects.toMatchObject({
+      message: 'Request timeout after 300ms',
+      code: 'TIMEOUT'
+    });
 
     const elapsed = Date.now() - start;
     expect(elapsed).toBeGreaterThanOrEqual(300);
@@ -311,9 +349,12 @@ describe('Starknet provider timeout', () => {
 });
 
 describe('withTimeout()', () => {
-  const response = new Response('{}');
+  // A fresh one per test: the deadline now clears when the body is read, so
+  // these tests consume it.
+  const jsonResponse = () => new Response('{}');
 
   test('calls the wrapped fetch and preserves its init', async () => {
+    const response = jsonResponse();
     const baseFetch = vi.fn().mockResolvedValue(response);
     const init = { method: 'POST', body: '{}', headers: { a: 'b' } };
 
@@ -332,14 +373,37 @@ describe('withTimeout()', () => {
     expect(withTimeout(baseFetch, 0)).toBe(baseFetch);
   });
 
-  test('clears its timer so a resolved request holds nothing open', async () => {
+  test('clears its timer so a read request holds nothing open', async () => {
     const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
-    const baseFetch = vi.fn().mockResolvedValue(response);
+    const baseFetch = vi.fn().mockResolvedValue(jsonResponse());
 
-    await withTimeout(baseFetch, 1000)('https://rpc.test', {});
+    const response = await withTimeout(baseFetch, 1000)('https://rpc.test', {});
+    expect(clearTimeoutSpy).not.toHaveBeenCalled();
+    await response.json();
 
     expect(clearTimeoutSpy).toHaveBeenCalled();
     clearTimeoutSpy.mockRestore();
+  });
+
+  test('maps a timeout during the body read, not just the headers', async () => {
+    // Stands in for node-fetch, whose body stream errors on the abort.
+    const baseFetch = vi.fn((_url: any, init: RequestInit = {}) =>
+      Promise.resolve({
+        json: () =>
+          new Promise((_resolve, reject) =>
+            init.signal?.addEventListener('abort', () =>
+              reject(init.signal?.reason)
+            )
+          )
+      } as unknown as Response)
+    );
+
+    const response = await withTimeout(baseFetch, 50)('https://rpc.test', {});
+
+    await expect(response.json()).rejects.toMatchObject({
+      message: 'Request timeout after 50ms',
+      code: 'TIMEOUT'
+    });
   });
 
   test('does not rewrite an error that is not its own timeout', async () => {
@@ -387,11 +451,12 @@ describe('withTimeout()', () => {
   test('stops listening on the caller signal once the request settles', async () => {
     const caller = new AbortController();
     const removeEventListener = vi.spyOn(caller.signal, 'removeEventListener');
-    const baseFetch = vi.fn().mockResolvedValue(response);
+    const baseFetch = vi.fn().mockResolvedValue(jsonResponse());
 
-    await withTimeout(baseFetch, 1000)('https://rpc.test', {
+    const response = await withTimeout(baseFetch, 1000)('https://rpc.test', {
       signal: caller.signal
     });
+    await response.json();
 
     expect(removeEventListener).toHaveBeenCalledWith(
       'abort',

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 import { AddressInfo, createServer, Server, Socket } from 'net';
+import crossFetch from 'cross-fetch';
 import getProvider, { withTimeout } from '../../../src/utils/provider';
 import { getViemClient } from '../../../src/utils/viem';
 import { RpcProvider } from 'starknet';
@@ -279,6 +280,22 @@ describe('Starknet provider timeout', () => {
     });
   });
 
+  test('lets a caller abort cancel a hung request before the timeout', async () => {
+    // The fetch we actually ship, against the same hung node: an abort from
+    // above has to reach the socket rather than sit behind the 5s timeout.
+    const caller = new AbortController();
+    const start = Date.now();
+    const request = withTimeout(crossFetch, 5000)(broviderUrl, {
+      method: 'POST',
+      body: '{}',
+      signal: caller.signal
+    });
+    setTimeout(() => caller.abort(), 50);
+
+    await expect(request).rejects.toMatchObject({ name: 'AbortError' });
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+
   test('applies the default timeout when none is passed', async () => {
     // Fake only the timers this uses, so the pending socket is untouched and
     // the suite does not sit here for the full 25s.
@@ -336,5 +353,57 @@ describe('withTimeout()', () => {
     await expect(
       withTimeout(baseFetch, 1000)('https://rpc.test', {})
     ).rejects.toThrow('network down');
+  });
+
+  // A fetch that settles only on an abort of the signal it was handed, up front
+  // or later, as a real fetch does. These fail if the caller's signal is
+  // dropped instead of composed.
+  const signalRespectingFetch = () =>
+    vi.fn((_url: any, init: RequestInit = {}) => {
+      const { signal } = init;
+      return new Promise<Response>((_resolve, reject) => {
+        if (signal?.aborted) return reject(signal.reason);
+        signal?.addEventListener('abort', () => reject(signal.reason));
+      });
+    });
+
+  test('rejects on a caller abort with the caller reason, not a timeout', async () => {
+    const caller = new AbortController();
+    const reason = new Error('caller gave up');
+    const request = withTimeout(signalRespectingFetch(), 30000)(
+      'https://rpc.test',
+      { signal: caller.signal }
+    );
+
+    caller.abort(reason);
+
+    await expect(request).rejects.toBe(reason);
+  });
+
+  test('aborts at once when the caller signal is already aborted', async () => {
+    const caller = new AbortController();
+    const reason = new Error('caller gave up first');
+    caller.abort(reason);
+
+    await expect(
+      withTimeout(signalRespectingFetch(), 30000)('https://rpc.test', {
+        signal: caller.signal
+      })
+    ).rejects.toBe(reason);
+  });
+
+  test('stops listening on the caller signal once the request settles', async () => {
+    const caller = new AbortController();
+    const removeEventListener = vi.spyOn(caller.signal, 'removeEventListener');
+    const baseFetch = vi.fn().mockResolvedValue(response);
+
+    await withTimeout(baseFetch, 1000)('https://rpc.test', {
+      signal: caller.signal
+    });
+
+    expect(removeEventListener).toHaveBeenCalledWith(
+      'abort',
+      expect.any(Function)
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4834,7 +4834,7 @@ stackback@0.0.2:
   resolved "https://registry.yarnpkg.com/@starknet-io/types-js/-/types-js-0.7.10.tgz#d21dc973d0cd04d7b6293ce461f2f06a5873c760"
   integrity sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==
 
-starknet@^6.11.0:
+starknet@^6.21.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/starknet/-/starknet-6.24.1.tgz#87333339795038e93ef32a20726b5272ddb78fe1"
   integrity sha512-g7tiCt73berhcNi41otlN3T3kxZnIvZhMi8WdC21Y6GC6zoQgbI2z1t7JAZF9c4xZiomlanwVnurcpyfEdyMpg==


### PR DESCRIPTION
Fixes #1224.

### What was broken

`getStarknetProvider` forwarded only `nodeUrl`, so a caller-supplied `timeout` and the default were both dropped. The EVM provider and the viem client pass it through, so this was Starknet only.

Nothing downstream picked up the slack: starknet.js v6 has no timeout option and calls its transport with no signal of its own, so a node that accepts the connection and never answers hangs rather than throws. And a hang is not contained by a caller's `try/catch` the way a throw is: stamp's avatar endpoint fans its resolvers out under one `Promise.all` and the Starknet one uses this provider, so a single unresponsive RPC stalls the whole request.

### The fix

`RpcProviderOptions` has no `timeout`, but it does accept `baseFetch`, so the deadline goes on the fetch: a wrapper around native `fetch` that aborts the request once the timeout elapses. What it has to get right:

- The deadline is held until the response body is read, not until the fetch settles. `fetch` resolves as soon as the headers are in, and nothing bounds the read that follows.
- A caller `signal` is composed with the timeout rather than replaced, so a genuine caller abort still surfaces as itself.
- Bad input can neither disable the bound nor collapse it to the next tick: `normalizeOptions` sends a non-finite or negative `timeout` back to the default and caps it at the largest delay `setTimeout` accepts.

The wrapper is generic and lives in its own leaf module, `src/utils/fetch.ts`, with its tests alongside it. Leaf means it imports nothing, so it adds no cycle. Starknet's constraint stays at the call site instead of in the primitive: `RpcChannel` re-throws anything that is not a `LibraryError` as a bare `Error` and drops the `code`, so `getStarknetProvider` hands in an error factory producing a `LibraryError` with `code: 'TIMEOUT'` — the code ethers puts on the EVM provider's timeout, so both providers now fail the same way and stamp's `isSilencedError` recognises both.

The `starknet` floor moves up to the 6.x where `RpcProviderOptions.baseFetch` first exists; below that the wrapper is handed to a constructor that never calls it, and the emitted `.d.ts` fails `tsc` for consumers. The resolved version is unchanged.

`utils.fetch` keeps its own implementation rather than adopting the primitive: that would change two behaviours of a published function, which is semver-visible and wants its own PR.
