### PR TITLE
refactor(provider): extract the timeout-bounded fetch into src/utils/fetch.ts

### DIFF
--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,0 +1,73 @@
+export type FetchLike = (
+  input: RequestInfo | URL,
+  init?: RequestInit
+) => Promise<Response>;
+
+export interface WithTimeoutOptions {
+  // For callers whose stack constrains the error type, e.g. starknet's
+  // RpcChannel. The default is a plain `Error`.
+  timeoutError?: (timeout: number) => Error;
+}
+
+const defaultTimeoutError = (timeout: number) =>
+  new Error(`Request timeout after ${timeout}ms`);
+
+// Not `AbortSignal.timeout`: it would raise the browser bundle's floor to
+// Safari 16.
+export function withTimeout(
+  fetchFn: FetchLike,
+  timeout: number,
+  { timeoutError = defaultTimeoutError }: WithTimeoutOptions = {}
+): FetchLike {
+  // Without this, `setTimeout(..., 0)` aborts every request on the next tick.
+  if (timeout <= 0) return fetchFn;
+
+  return async (url, init) => {
+    const controller = new AbortController();
+    const callerSignal = init?.signal;
+    const abortFromCaller = () => controller.abort(callerSignal?.reason);
+    let timedOut = false;
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      callerSignal?.removeEventListener('abort', abortFromCaller);
+    };
+    // Cleans up after itself: nothing else will if the body is never read.
+    const timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+      cleanup();
+    }, timeout);
+    // Node-only: browser timers are numbers with no `unref`. Without this,
+    // an unread response body holds the event loop open for the full
+    // timeout even though the request already finished.
+    if (typeof timer === 'object' && 'unref' in timer) timer.unref();
+
+    if (callerSignal?.aborted) abortFromCaller();
+    else callerSignal?.addEventListener('abort', abortFromCaller);
+
+    let response: Response;
+    try {
+      response = await fetchFn(url, { ...init, signal: controller.signal });
+    } catch (e) {
+      cleanup();
+      throw timedOut ? timeoutError(timeout) : e;
+    }
+
+    // Resolving only means the headers arrived: a caller reading the body
+    // afterwards with its own `.json()` gets no bound from node-fetch on the
+    // body stream or the parse. Hold the deadline until that settles.
+    const json = response.json.bind(response);
+    response.json = async () => {
+      try {
+        return await json();
+      } catch (e) {
+        throw timedOut ? timeoutError(timeout) : e;
+      } finally {
+        cleanup();
+      }
+    };
+
+    return response;
+  };
+}

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -14,13 +14,15 @@ const defaultTimeoutError = (timeout: number) =>
 
 // Every body reader a `Response` may carry, patched only where it exists:
 // node-fetch 2 ships no `formData`, and a hand-rolled test double has only
-// the reader it needs.
-export const BODY_READERS: readonly (keyof Response)[] = [
+// the reader it needs. `bytes` is spelled out because TypeScript's DOM lib
+// does not carry it yet, though Node 22 does.
+export const BODY_READERS: readonly (keyof Response | 'bytes')[] = [
   'json',
   'text',
   'arrayBuffer',
   'blob',
-  'formData'
+  'formData',
+  'bytes'
 ];
 
 // Not `AbortSignal.timeout`: it would raise the browser bundle's floor to

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -4,8 +4,8 @@ export type FetchLike = (
 ) => Promise<Response>;
 
 export interface WithTimeoutOptions {
-  // For callers whose stack constrains the error type, e.g. starknet's
-  // RpcChannel. The default is a plain `Error`.
+  // For callers whose stack constrains the error type. The default is a
+  // plain `Error`.
   timeoutError?: (timeout: number) => Error;
 }
 
@@ -15,7 +15,13 @@ const defaultTimeoutError = (timeout: number) =>
 // Every body reader a `Response` may carry, patched only where it exists:
 // node-fetch 2 ships no `formData`, and a hand-rolled test double has only
 // the reader it needs.
-const BODY_READERS = ['json', 'text', 'arrayBuffer', 'blob', 'formData'];
+export const BODY_READERS: readonly (keyof Response)[] = [
+  'json',
+  'text',
+  'arrayBuffer',
+  'blob',
+  'formData'
+];
 
 // Not `AbortSignal.timeout`: it would raise the browser bundle's floor to
 // Safari 16.

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -19,7 +19,9 @@ export function withTimeout(
   timeout: number,
   { timeoutError = defaultTimeoutError }: WithTimeoutOptions = {}
 ): FetchLike {
-  // Without this, `setTimeout(..., 0)` aborts every request on the next tick.
+  // A precondition of the primitive, not a live path: the only caller in this
+  // repo gates the install above 0. Without it, `setTimeout(..., 0)` would
+  // abort every request on the next tick.
   if (timeout <= 0) return fetchFn;
 
   return async (url, init) => {

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -12,6 +12,11 @@ export interface WithTimeoutOptions {
 const defaultTimeoutError = (timeout: number) =>
   new Error(`Request timeout after ${timeout}ms`);
 
+// Every body reader a `Response` may carry, patched only where it exists:
+// node-fetch 2 ships no `formData`, and a hand-rolled test double has only
+// the reader it needs.
+const BODY_READERS = ['json', 'text', 'arrayBuffer', 'blob', 'formData'];
+
 // Not `AbortSignal.timeout`: it would raise the browser bundle's floor to
 // Safari 16.
 export function withTimeout(
@@ -56,19 +61,30 @@ export function withTimeout(
       throw timedOut ? timeoutError(timeout) : e;
     }
 
-    // Resolving only means the headers arrived: a caller reading the body
-    // afterwards with its own `.json()` gets no bound from node-fetch on the
-    // body stream or the parse. Hold the deadline until that settles.
-    const json = response.json.bind(response);
-    response.json = async () => {
-      try {
-        return await json();
-      } catch (e) {
-        throw timedOut ? timeoutError(timeout) : e;
-      } finally {
-        cleanup();
-      }
-    };
+    // Resolving only means the headers arrived: the body stream and the parse
+    // that follow are bounded by nothing. Hold the deadline over whichever
+    // reader the caller picks, so the deadline covers all of them and each one
+    // reports it the same way. Reading `response.body` as a stream is the one
+    // path this cannot reach; that still surfaces the raw abort.
+    const readers = response as unknown as Record<
+      string,
+      undefined | (() => Promise<unknown>)
+    >;
+    for (const name of BODY_READERS) {
+      const read = readers[name];
+      if (typeof read !== 'function') continue;
+
+      const bound = read.bind(response);
+      readers[name] = async () => {
+        try {
+          return await bound();
+        } catch (e) {
+          throw timedOut ? timeoutError(timeout) : e;
+        } finally {
+          cleanup();
+        }
+      };
+    }
 
     return response;
   };

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -1,5 +1,6 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
-import { LibraryError, RpcProvider, RpcProviderOptions } from 'starknet';
+import { LibraryError, RpcProvider } from 'starknet';
+import { withTimeout } from './fetch';
 import networks from '../networks.json';
 
 export interface ProviderOptions {
@@ -96,71 +97,13 @@ function getEvmProvider(
   );
 }
 
-type BaseFetch = NonNullable<RpcProviderOptions['baseFetch']>;
-
-// Not `AbortSignal.timeout`: it would raise the browser bundle's floor to
-// Safari 16.
-export function withTimeout(baseFetch: BaseFetch, timeout: number): BaseFetch {
-  // getStarknetProvider never calls in at 0, so this is the export's own
-  // precondition rather than a live path: without it, `setTimeout(..., 0)`
-  // would abort every request on the next tick.
-  if (timeout <= 0) return baseFetch;
-
-  return async (url, init) => {
-    const controller = new AbortController();
-    const callerSignal = init?.signal;
-    const abortFromCaller = () => controller.abort(callerSignal?.reason);
-    let timedOut = false;
-
-    const cleanup = () => {
-      clearTimeout(timer);
-      callerSignal?.removeEventListener('abort', abortFromCaller);
-    };
-    // Cleans up after itself: nothing else will if the body is never read.
-    const timer = setTimeout(() => {
-      timedOut = true;
-      controller.abort();
-      cleanup();
-    }, timeout);
-    // Node-only: browser timers are numbers with no `unref`. Without this,
-    // an unread response body holds the event loop open for the full
-    // timeout even though the request already finished.
-    if (typeof timer === 'object' && 'unref' in timer) timer.unref();
-
-    // LibraryError specifically: RpcChannel#errorHandler re-throws anything
-    // else as a bare `Error(message)`, which would drop `code`.
-    const timeoutError = () =>
-      Object.assign(new LibraryError(`Request timeout after ${timeout}ms`), {
-        code: 'TIMEOUT'
-      });
-
-    if (callerSignal?.aborted) abortFromCaller();
-    else callerSignal?.addEventListener('abort', abortFromCaller);
-
-    let response: Response;
-    try {
-      response = await baseFetch(url, { ...init, signal: controller.signal });
-    } catch (e) {
-      cleanup();
-      throw timedOut ? timeoutError() : e;
-    }
-
-    // Resolving only means the headers arrived; nothing bounds the body stream
-    // or the parse that follow. Hold the deadline over RpcChannel's read.
-    const json = response.json.bind(response);
-    response.json = async () => {
-      try {
-        return await json();
-      } catch (e) {
-        throw timedOut ? timeoutError() : e;
-      } finally {
-        cleanup();
-      }
-    };
-
-    return response;
-  };
-}
+// LibraryError specifically: RpcChannel#errorHandler re-throws anything else
+// as a bare `Error(message)`, which would drop `code`. Nothing outside this
+// call site needs it, so it stays out of the primitive.
+const starknetTimeoutError = (timeout: number) =>
+  Object.assign(new LibraryError(`Request timeout after ${timeout}ms`), {
+    code: 'TIMEOUT'
+  });
 
 function getStarknetProvider(
   networkKey: string,
@@ -176,7 +119,9 @@ function getStarknetProvider(
     // connection reuse), an XHR ponyfill in the bundled browser build.
     baseFetch:
       options.timeout > 0
-        ? withTimeout(fetch.bind(globalThis), options.timeout)
+        ? withTimeout(fetch.bind(globalThis), options.timeout, {
+            timeoutError: starknetTimeoutError
+          })
         : undefined
   });
 }

--- a/test/integration/utils/fetch.spec.ts
+++ b/test/integration/utils/fetch.spec.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 import { AddressInfo, createServer, Server, Socket } from 'net';
-import { withTimeout } from '../../../src/utils/fetch';
+import { BODY_READERS, withTimeout } from '../../../src/utils/fetch';
 
 describe('withTimeout()', () => {
   // A fresh one per test: the deadline clears when the body is read, so these
@@ -121,7 +121,7 @@ describe('withTimeout()', () => {
   // The primitive advertises a plain `FetchLike`, so a caller is free to read
   // the body with any of these; the deadline and the error have to be the same
   // whichever one it picks.
-  test.each(['json', 'text', 'arrayBuffer', 'blob', 'formData'])(
+  test.each(BODY_READERS)(
     'maps the timeout for a caller reading the body with .%s()',
     async (reader) => {
       const timeoutError = () =>

--- a/test/integration/utils/fetch.spec.ts
+++ b/test/integration/utils/fetch.spec.ts
@@ -222,7 +222,15 @@ describe('withTimeout() over a real socket', () => {
   let url: string;
 
   beforeAll(async () => {
-    server = createServer((socket) => sockets.push(socket));
+    // A caller abort ends the request mid-flight, so an RST is expected; an
+    // unhandled 'error' on a socket takes the worker down rather than
+    // failing a test.
+    server = createServer((socket) => {
+      socket.on('error', () => {
+        /* expected */
+      });
+      sockets.push(socket);
+    });
     await new Promise<void>((resolve) =>
       server.listen(0, '127.0.0.1', () => resolve())
     );

--- a/test/integration/utils/fetch.spec.ts
+++ b/test/integration/utils/fetch.spec.ts
@@ -16,18 +16,21 @@ describe('withTimeout()', () => {
       });
     });
 
-  // Stands in for node-fetch, whose body stream errors on the abort.
-  const stallingBodyFetch = () =>
-    vi.fn((_url: any, init: RequestInit = {}) =>
-      Promise.resolve({
-        json: () =>
-          new Promise((_resolve, reject) =>
-            init.signal?.addEventListener('abort', () =>
-              reject(init.signal?.reason)
-            )
+  // Stands in for a real transport, whose body stream errors on the abort.
+  const stallingBodyFetch = (readers = ['json']) =>
+    vi.fn((_url: any, init: RequestInit = {}) => {
+      const stall = () =>
+        new Promise((_resolve, reject) =>
+          init.signal?.addEventListener('abort', () =>
+            reject(init.signal?.reason)
           )
-      } as unknown as Response)
-    );
+        );
+      return Promise.resolve(
+        Object.fromEntries(
+          readers.map((name) => [name, stall])
+        ) as unknown as Response
+      );
+    });
 
   test('calls the wrapped fetch and preserves its init', async () => {
     const response = jsonResponse();
@@ -113,6 +116,37 @@ describe('withTimeout()', () => {
       message: 'gone',
       code: 'TIMEOUT'
     });
+  });
+
+  // The primitive advertises a plain `FetchLike`, so a caller is free to read
+  // the body with any of these; the deadline and the error have to be the same
+  // whichever one it picks.
+  test.each(['json', 'text', 'arrayBuffer', 'blob', 'formData'])(
+    'maps the timeout for a caller reading the body with .%s()',
+    async (reader) => {
+      const timeoutError = () =>
+        Object.assign(new Error('gone'), { code: 'TIMEOUT' });
+      const response = await withTimeout(stallingBodyFetch([reader]), 50, {
+        timeoutError
+      })('https://rpc.test', {});
+
+      await expect((response as any)[reader]()).rejects.toMatchObject({
+        message: 'gone',
+        code: 'TIMEOUT'
+      });
+    }
+  );
+
+  test('clears its timer for a caller reading the body with .text()', async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const baseFetch = vi.fn().mockResolvedValue(new Response('hello'));
+
+    const response = await withTimeout(baseFetch, 1000)('https://rpc.test', {});
+    expect(clearTimeoutSpy).not.toHaveBeenCalled();
+    await response.text();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
   });
 
   test('does not rewrite an error that is not its own timeout', async () => {
@@ -205,7 +239,10 @@ describe('withTimeout() over a real socket', () => {
     const start = Date.now();
 
     await expect(
-      withTimeout(fetch.bind(globalThis), 300)(url, { method: 'POST', body: '{}' })
+      withTimeout(fetch.bind(globalThis), 300)(url, {
+        method: 'POST',
+        body: '{}'
+      })
     ).rejects.toThrow('Request timeout after 300ms');
 
     const elapsed = Date.now() - start;

--- a/test/integration/utils/fetch.spec.ts
+++ b/test/integration/utils/fetch.spec.ts
@@ -118,6 +118,24 @@ describe('withTimeout()', () => {
     });
   });
 
+  // Derived from the runtime rather than from BODY_READERS, because the matrix
+  // below cannot see a reader the list forgot: `bytes` escaped the deadline
+  // that way. Everything on `Response.prototype` reads the body except these.
+  const NON_READERS = ['constructor', 'clone'];
+  const runtimeBodyReaders = Object.entries(
+    Object.getOwnPropertyDescriptors(Response.prototype)
+  )
+    .filter(
+      ([name, { value }]) =>
+        typeof value === 'function' && !NON_READERS.includes(name)
+    )
+    .map(([name]) => name);
+
+  test('covers every body reader the runtime exposes', () => {
+    expect(runtimeBodyReaders.length).toBeGreaterThan(0);
+    expect(BODY_READERS).toEqual(expect.arrayContaining(runtimeBodyReaders));
+  });
+
   // The primitive advertises a plain `FetchLike`, so a caller is free to read
   // the body with any of these; the deadline and the error have to be the same
   // whichever one it picks.

--- a/test/integration/utils/fetch.spec.ts
+++ b/test/integration/utils/fetch.spec.ts
@@ -1,0 +1,229 @@
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+import { AddressInfo, createServer, Server, Socket } from 'net';
+import { withTimeout } from '../../../src/utils/fetch';
+
+describe('withTimeout()', () => {
+  // A fresh one per test: the deadline clears when the body is read, so these
+  // tests consume it.
+  const jsonResponse = () => new Response('{}');
+
+  const signalRespectingFetch = () =>
+    vi.fn((_url: any, init: RequestInit = {}) => {
+      const { signal } = init;
+      return new Promise<Response>((_resolve, reject) => {
+        if (signal?.aborted) return reject(signal.reason);
+        signal?.addEventListener('abort', () => reject(signal.reason));
+      });
+    });
+
+  // Stands in for node-fetch, whose body stream errors on the abort.
+  const stallingBodyFetch = () =>
+    vi.fn((_url: any, init: RequestInit = {}) =>
+      Promise.resolve({
+        json: () =>
+          new Promise((_resolve, reject) =>
+            init.signal?.addEventListener('abort', () =>
+              reject(init.signal?.reason)
+            )
+          )
+      } as unknown as Response)
+    );
+
+  test('calls the wrapped fetch and preserves its init', async () => {
+    const response = jsonResponse();
+    const baseFetch = vi.fn().mockResolvedValue(response);
+    const init = { method: 'POST', body: '{}', headers: { a: 'b' } };
+
+    await expect(
+      withTimeout(baseFetch, 1000)('https://rpc.test', init)
+    ).resolves.toBe(response);
+    expect(baseFetch).toHaveBeenCalledWith(
+      'https://rpc.test',
+      expect.objectContaining({ ...init, signal: expect.any(AbortSignal) })
+    );
+  });
+
+  test('returns the wrapped fetch untouched when the timeout is disabled', () => {
+    const baseFetch = vi.fn();
+
+    expect(withTimeout(baseFetch, 0)).toBe(baseFetch);
+    expect(withTimeout(baseFetch, -1)).toBe(baseFetch);
+  });
+
+  test('clears its timer so a read request holds nothing open', async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const baseFetch = vi.fn().mockResolvedValue(jsonResponse());
+
+    const response = await withTimeout(baseFetch, 1000)('https://rpc.test', {});
+    expect(clearTimeoutSpy).not.toHaveBeenCalled();
+    await response.json();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+
+  test('unrefs its timer so an unread body holds nothing open', async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const baseFetch = vi.fn().mockResolvedValue(jsonResponse());
+
+    // Resolve the response and never read the body: cleanup() cannot run.
+    await withTimeout(baseFetch, 1000)('https://rpc.test', {});
+
+    expect(setTimeoutSpy.mock.results[0].value.hasRef()).toBe(false);
+    setTimeoutSpy.mockRestore();
+  });
+
+  test('rejects with a timeout error when the headers never arrive', async () => {
+    await expect(
+      withTimeout(signalRespectingFetch(), 50)('https://rpc.test', {})
+    ).rejects.toThrow('Request timeout after 50ms');
+  });
+
+  test('maps a timeout during the body read, not just the headers', async () => {
+    const response = await withTimeout(stallingBodyFetch(), 50)(
+      'https://rpc.test',
+      {}
+    );
+
+    await expect(response.json()).rejects.toThrow('Request timeout after 50ms');
+  });
+
+  test('builds the timeout error with the supplied factory', async () => {
+    const timeoutError = vi.fn(
+      (timeout: number) => new Error(`gone ${timeout}`)
+    );
+
+    await expect(
+      withTimeout(signalRespectingFetch(), 50, { timeoutError })(
+        'https://rpc.test',
+        {}
+      )
+    ).rejects.toThrow('gone 50');
+    expect(timeoutError).toHaveBeenCalledWith(50);
+  });
+
+  test('uses the supplied factory on the body read too', async () => {
+    const timeoutError = () =>
+      Object.assign(new Error('gone'), { code: 'TIMEOUT' });
+    const response = await withTimeout(stallingBodyFetch(), 50, {
+      timeoutError
+    })('https://rpc.test', {});
+
+    await expect(response.json()).rejects.toMatchObject({
+      message: 'gone',
+      code: 'TIMEOUT'
+    });
+  });
+
+  test('does not rewrite an error that is not its own timeout', async () => {
+    const baseFetch = vi.fn().mockRejectedValue(new Error('network down'));
+
+    await expect(
+      withTimeout(baseFetch, 1000)('https://rpc.test', {})
+    ).rejects.toThrow('network down');
+  });
+
+  test('rejects on a caller abort with the caller reason, not a timeout', async () => {
+    const caller = new AbortController();
+    const reason = new Error('caller gave up');
+    const request = withTimeout(signalRespectingFetch(), 30000)(
+      'https://rpc.test',
+      { signal: caller.signal }
+    );
+
+    caller.abort(reason);
+
+    await expect(request).rejects.toBe(reason);
+  });
+
+  test('aborts at once when the caller signal is already aborted', async () => {
+    const caller = new AbortController();
+    const reason = new Error('caller gave up first');
+    caller.abort(reason);
+
+    await expect(
+      withTimeout(signalRespectingFetch(), 30000)('https://rpc.test', {
+        signal: caller.signal
+      })
+    ).rejects.toBe(reason);
+  });
+
+  test('unhooks the caller signal when the deadline fires on an unread body', async () => {
+    const caller = new AbortController();
+    const removeEventListener = vi.spyOn(caller.signal, 'removeEventListener');
+
+    await withTimeout(stallingBodyFetch(), 20)('https://rpc.test', {
+      signal: caller.signal
+    });
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    expect(removeEventListener).toHaveBeenCalledWith(
+      'abort',
+      expect.any(Function)
+    );
+  });
+
+  test('stops listening on the caller signal once the request settles', async () => {
+    const caller = new AbortController();
+    const removeEventListener = vi.spyOn(caller.signal, 'removeEventListener');
+    const baseFetch = vi.fn().mockResolvedValue(jsonResponse());
+
+    const response = await withTimeout(baseFetch, 1000)('https://rpc.test', {
+      signal: caller.signal
+    });
+    await response.json();
+
+    expect(removeEventListener).toHaveBeenCalledWith(
+      'abort',
+      expect.any(Function)
+    );
+  });
+});
+
+describe('withTimeout() over a real socket', () => {
+  // Accepts the connection and never answers; a refused connection would fail
+  // fast on its own.
+  let server: Server;
+  let sockets: Socket[] = [];
+  let url: string;
+
+  beforeAll(async () => {
+    server = createServer((socket) => sockets.push(socket));
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', () => resolve())
+    );
+    url = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterAll(async () => {
+    sockets.forEach((socket) => socket.destroy());
+    sockets = [];
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  test('rejects a hung request instead of waiting on the runtime', async () => {
+    const start = Date.now();
+
+    await expect(
+      withTimeout(fetch.bind(globalThis), 300)(url, { method: 'POST', body: '{}' })
+    ).rejects.toThrow('Request timeout after 300ms');
+
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(300);
+    expect(elapsed).toBeLessThan(3000);
+  });
+
+  test('lets a caller abort cancel a hung request before the timeout', async () => {
+    const caller = new AbortController();
+    const start = Date.now();
+    const request = withTimeout(fetch.bind(globalThis), 5000)(url, {
+      method: 'POST',
+      body: '{}',
+      signal: caller.signal
+    });
+    setTimeout(() => caller.abort(), 50);
+
+    await expect(request).rejects.toMatchObject({ name: 'AbortError' });
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+});

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -358,23 +358,12 @@ describe('Starknet provider timeout', () => {
       broviderUrl,
       timeout: 400
     });
+    const request = provider.getSpecVersion();
 
-    await expect(provider.getSpecVersion()).rejects.toMatchObject({
-      code: 'TIMEOUT'
-    });
-  });
-
-  // A plain Error would come back out of RpcChannel#errorHandler stripped of
-  // `code`, so the class is what keeps the assertion above true.
-  test('rejects with a LibraryError, the only class that keeps the code', async () => {
-    const provider = getProvider(STARKNET_NETWORK, {
-      broviderUrl,
-      timeout: 400
-    });
-
-    await expect(provider.getSpecVersion()).rejects.toBeInstanceOf(
-      LibraryError
-    );
+    // A plain Error would come back out of RpcChannel#errorHandler stripped of
+    // `code`, so the class is what keeps the code assertion true.
+    await expect(request).rejects.toBeInstanceOf(LibraryError);
+    await expect(request).rejects.toMatchObject({ code: 'TIMEOUT' });
   });
 
   test('applies the default timeout when none is passed', async () => {

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -249,10 +249,19 @@ describe('Starknet provider timeout', () => {
   };
 
   beforeAll(async () => {
-    server = createServer((socket) => sockets.push(socket));
-    headersOnlyServer = createServer((socket) => {
+    // The deadline aborts mid-request, so an RST is expected; an unhandled
+    // 'error' on a socket takes the worker down rather than failing a test.
+    const accept = (socket: Socket) => {
+      socket.on('error', () => {
+        /* expected */
+      });
       sockets.push(socket);
-      socket.on('data', () =>
+      return socket;
+    };
+
+    server = createServer(accept);
+    headersOnlyServer = createServer((socket) => {
+      accept(socket).on('data', () =>
         socket.write(
           'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 24\r\n\r\n'
         )

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -2,11 +2,10 @@ import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 import { AddressInfo, createServer, Server, Socket } from 'net';
 import getProvider, {
   DEFAULT_TIMEOUT,
-  normalizeOptions,
-  withTimeout
+  normalizeOptions
 } from '../../../src/utils/provider';
 import { getViemClient } from '../../../src/utils/viem';
-import { RpcProvider } from 'starknet';
+import { LibraryError, RpcProvider } from 'starknet';
 
 const STARKNET_NETWORK = '0x534e5f4d41494e';
 
@@ -356,18 +355,17 @@ describe('Starknet provider timeout', () => {
     });
   });
 
-  test('lets a caller abort cancel a hung request before the timeout', async () => {
-    const caller = new AbortController();
-    const start = Date.now();
-    const request = withTimeout(fetch.bind(globalThis), 5000)(broviderUrl, {
-      method: 'POST',
-      body: '{}',
-      signal: caller.signal
+  // A plain Error would come back out of RpcChannel#errorHandler stripped of
+  // `code`, so the class is what keeps the assertion above true.
+  test('rejects with a LibraryError, the only class that keeps the code', async () => {
+    const provider = getProvider(STARKNET_NETWORK, {
+      broviderUrl,
+      timeout: 400
     });
-    setTimeout(() => caller.abort(), 50);
 
-    await expect(request).rejects.toMatchObject({ name: 'AbortError' });
-    expect(Date.now() - start).toBeLessThan(1000);
+    await expect(provider.getSpecVersion()).rejects.toBeInstanceOf(
+      LibraryError
+    );
   });
 
   test('applies the default timeout when none is passed', async () => {
@@ -384,133 +382,6 @@ describe('Starknet provider timeout', () => {
     } finally {
       vi.useRealTimers();
     }
-  });
-});
-
-describe('withTimeout()', () => {
-  // A factory, not a shared const: reading the body clears the deadline.
-  const jsonResponse = () => new Response('{}');
-
-  test('calls the wrapped fetch and preserves its init', async () => {
-    const response = jsonResponse();
-    const baseFetch = vi.fn().mockResolvedValue(response);
-    const init = { method: 'POST', body: '{}', headers: { a: 'b' } };
-
-    await expect(
-      withTimeout(baseFetch, 1000)('https://rpc.test', init)
-    ).resolves.toBe(response);
-    expect(baseFetch).toHaveBeenCalledWith(
-      'https://rpc.test',
-      expect.objectContaining({ ...init, signal: expect.any(AbortSignal) })
-    );
-  });
-
-  test('returns the wrapped fetch untouched when the timeout is disabled', () => {
-    const baseFetch = vi.fn();
-
-    expect(withTimeout(baseFetch, 0)).toBe(baseFetch);
-  });
-
-  test('clears its timer so a read request holds nothing open', async () => {
-    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout');
-    const baseFetch = vi.fn().mockResolvedValue(jsonResponse());
-
-    const response = await withTimeout(baseFetch, 1000)('https://rpc.test', {});
-    expect(clearTimeoutSpy).not.toHaveBeenCalled();
-    await response.json();
-
-    expect(clearTimeoutSpy).toHaveBeenCalled();
-    clearTimeoutSpy.mockRestore();
-  });
-
-  test('unrefs its timer so an unread body holds nothing open', async () => {
-    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
-    const baseFetch = vi.fn().mockResolvedValue(jsonResponse());
-
-    // Resolve the response and never read the body: cleanup() cannot run.
-    await withTimeout(baseFetch, 1000)('https://rpc.test', {});
-
-    expect(setTimeoutSpy.mock.results[0].value.hasRef()).toBe(false);
-    setTimeoutSpy.mockRestore();
-  });
-
-  test('maps a timeout during the body read, not just the headers', async () => {
-    // Stands in for node-fetch, whose body stream errors on the abort.
-    const baseFetch = vi.fn((_url: any, init: RequestInit = {}) =>
-      Promise.resolve({
-        json: () =>
-          new Promise((_resolve, reject) =>
-            init.signal?.addEventListener('abort', () =>
-              reject(init.signal?.reason)
-            )
-          )
-      } as unknown as Response)
-    );
-
-    const response = await withTimeout(baseFetch, 50)('https://rpc.test', {});
-
-    await expect(response.json()).rejects.toMatchObject({
-      message: 'Request timeout after 50ms',
-      code: 'TIMEOUT'
-    });
-  });
-
-  test('does not rewrite an error that is not its own timeout', async () => {
-    const baseFetch = vi.fn().mockRejectedValue(new Error('network down'));
-
-    await expect(
-      withTimeout(baseFetch, 1000)('https://rpc.test', {})
-    ).rejects.toThrow('network down');
-  });
-
-  const signalRespectingFetch = () =>
-    vi.fn((_url: any, init: RequestInit = {}) => {
-      const { signal } = init;
-      return new Promise<Response>((_resolve, reject) => {
-        if (signal?.aborted) return reject(signal.reason);
-        signal?.addEventListener('abort', () => reject(signal.reason));
-      });
-    });
-
-  test('rejects on a caller abort with the caller reason, not a timeout', async () => {
-    const caller = new AbortController();
-    const reason = new Error('caller gave up');
-    const request = withTimeout(signalRespectingFetch(), 30000)(
-      'https://rpc.test',
-      { signal: caller.signal }
-    );
-
-    caller.abort(reason);
-
-    await expect(request).rejects.toBe(reason);
-  });
-
-  test('aborts at once when the caller signal is already aborted', async () => {
-    const caller = new AbortController();
-    const reason = new Error('caller gave up first');
-    caller.abort(reason);
-
-    await expect(
-      withTimeout(signalRespectingFetch(), 30000)('https://rpc.test', {
-        signal: caller.signal
-      })
-    ).rejects.toBe(reason);
-  });
-
-  test('stops listening on the caller signal once the request settles', async () => {
-    const caller = new AbortController();
-    const removeEventListener = vi.spyOn(caller.signal, 'removeEventListener');
-    const baseFetch = vi.fn().mockResolvedValue(jsonResponse());
-
-    const response = await withTimeout(baseFetch, 1000)('https://rpc.test', {
-      signal: caller.signal
-    });
-    await response.json();
-
-    expect(removeEventListener).toHaveBeenCalledWith(
-      'abort',
-      expect.any(Function)
-    );
   });
 });
 


### PR DESCRIPTION
Stacked on #1225, based on `fix/starknet-provider-timeout` rather than `master`, so that PR stays reviewable on its own and this one shows only the extraction. It needs to go in first.

### What this does

`withTimeout` moves out of `src/utils/provider.ts` into a new leaf module, `src/utils/fetch.ts`, with its tests alongside it. Leaf means it imports nothing at all, so it adds no cycle and either side of the duplication can reach it.

The primitive stays generic. The `LibraryError` carrying `code: 'TIMEOUT'` is a constraint of starknet's `RpcChannel`, which re-throws anything else as a bare `Error` and loses the `code`, so it moves to the `getStarknetProvider` call site and reaches the primitive as an optional error factory. The starknet-derived `BaseFetch` type becomes a local `FetchLike`, which is what lets the module import nothing.

### The one behaviour change

The deadline now covers every body reader, not just `.json()`. A caller reading the body any other way was still aborted at the deadline but got the raw `AbortError` rather than the supplied error, and a successful read on those paths left the timer armed instead of clearing it. That was defensible while the wrapper was private to `getStarknetProvider`, whose only callers read JSON; it is not once the same function is a leaf advertising a plain `FetchLike`. Reading `response.body` as a stream is still out of reach and still surfaces the raw abort, and the comment says so.

### What deliberately did not move

`utils.fetch` keeps its own implementation, even though it duplicates this mechanism. Adopting the primitive would change two behaviours of a published function: the deadline would start covering the body read, so a caller with a slow body would begin timing out where it does not today, and a caller `signal` would be composed rather than overridden, so an `AbortError` would newly escape a helper documented to throw `Request timeout after Nms`. That is semver-visible and wants its own PR rather than a ride on an extraction.

No public API change here: `withTimeout` was introduced in #1225 and has never been published, and it is not reachable from `src/index.ts` in either place.

