### PR TITLE
feat(provider): type getProvider's return per chain family

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "dev": "rollup -c -w",
     "lint": "eslint . --ext .ts",
     "lint:fix": "yarn lint --fix",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "prepublishOnly": "yarn build"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -12,6 +12,13 @@ type ProviderInstance = StaticJsonRpcProvider | RpcProvider;
 
 export type ProviderType = 'evm' | 'starknet';
 
+export const STARKNET_NETWORK_IDS = [
+  '0x534e5f4d41494e',
+  '0x534e5f5345504f4c4941'
+] as const;
+
+export type StarknetNetworkId = typeof STARKNET_NETWORK_IDS[number];
+
 const DEFAULT_BROVIDER_URL = 'https://rpc.snapshot.org' as const;
 export const DEFAULT_TIMEOUT = 25000 as const;
 
@@ -62,11 +69,22 @@ export function createMemoKey(
   return `${networkId}:${options.broviderUrl}:${options.timeout}`;
 }
 
-// return loose `any` type to avoid typecheck issues on package consumers
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+export type ProviderFor<T extends string | number> = IsAny<T> extends true
+  ? StaticJsonRpcProvider
+  : T extends StarknetNetworkId
+  ? RpcProvider
+  : StaticJsonRpcProvider;
+
+export default function getProvider<T extends string | number>(
+  network: T,
+  options?: ProviderOptions
+): ProviderFor<T>;
 export default function getProvider(
   network: string | number,
   options: ProviderOptions = {}
-): any {
+): ProviderInstance {
   const networkId = getBroviderNetworkId(network);
   const normalizedOptions = normalizeOptions(options);
   const memoKey = createMemoKey(networkId, normalizedOptions);

--- a/src/verify/starknet.ts
+++ b/src/verify/starknet.ts
@@ -1,5 +1,5 @@
 import { typedData, TypedData } from 'starknet';
-import type { ProviderOptions } from '../utils/provider';
+import type { ProviderOptions, StarknetNetworkId } from '../utils/provider';
 import type { SignaturePayload } from '.';
 import getProvider from '../utils/provider';
 
@@ -21,7 +21,7 @@ export default async function verify(
   address: string,
   sig: string[],
   data: SignaturePayload,
-  network = '0x534e5f4d41494e',
+  network: StarknetNetworkId = '0x534e5f4d41494e',
   options: ProviderOptions = {}
 ): Promise<boolean> {
   try {

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -2,9 +2,12 @@ import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 import { AddressInfo, createServer, Server, Socket } from 'net';
 import getProvider, {
   DEFAULT_TIMEOUT,
-  normalizeOptions
+  getProviderType,
+  normalizeOptions,
+  STARKNET_NETWORK_IDS
 } from '../../../src/utils/provider';
 import { getViemClient } from '../../../src/utils/viem';
+import networks from '../../../src/networks.json';
 import { LibraryError, RpcProvider } from 'starknet';
 
 const STARKNET_NETWORK = '0x534e5f4d41494e';
@@ -36,6 +39,14 @@ describe('test providers', () => {
     test('should throw an error for unsupported networks', () => {
       expect(() => getProvider('0x123')).toThrowError(
         "Network '0x123' is not supported"
+      );
+    });
+
+    test('should type every Starknet network in networks.json as Starknet', () => {
+      expect([...STARKNET_NETWORK_IDS].sort()).toEqual(
+        Object.keys(networks)
+          .filter((id) => getProviderType(id) === 'starknet')
+          .sort()
       );
     });
 

--- a/test/types/provider.test-d.ts
+++ b/test/types/provider.test-d.ts
@@ -1,0 +1,41 @@
+import type { StaticJsonRpcProvider } from '@ethersproject/providers';
+import type { RpcProvider } from 'starknet';
+import { constants } from 'starknet';
+import getProvider from '../../src/utils/provider';
+import snapshot from '../../src/index';
+
+declare const widenedString: string;
+declare const widenedNumber: number;
+declare const untyped: any;
+
+export const starknetMainnet: RpcProvider = getProvider('0x534e5f4d41494e');
+export const starknetSepolia: RpcProvider = getProvider(
+  '0x534e5f5345504f4c4941'
+);
+export const starknetFromChainId: RpcProvider = getProvider(
+  constants.StarknetChainId.SN_MAIN
+);
+export const ethereum: StaticJsonRpcProvider = getProvider('1');
+export const ethereumAsNumber: StaticJsonRpcProvider = getProvider(1);
+export const fromWidenedString: StaticJsonRpcProvider =
+  getProvider(widenedString);
+export const fromWidenedNumber: StaticJsonRpcProvider =
+  getProvider(widenedNumber);
+export const fromUntyped: StaticJsonRpcProvider = getProvider(untyped);
+
+export const throughPublicSurface: RpcProvider =
+  snapshot.utils.getProvider('0x534e5f4d41494e');
+export const throughPublicSurfaceEvm: StaticJsonRpcProvider =
+  snapshot.utils.getProvider('1');
+
+// @ts-expect-error a Starknet network resolves to starknet.js, not ethers
+export const notEthers: StaticJsonRpcProvider = getProvider('0x534e5f4d41494e');
+
+// @ts-expect-error an EVM network resolves to ethers, not starknet.js
+export const notStarknet: RpcProvider = getProvider('1');
+
+// @ts-expect-error a network the compiler cannot pin resolves to ethers
+export const notStarknetFromUntyped: RpcProvider = getProvider(untyped);
+
+// @ts-expect-error a network the compiler cannot pin resolves to ethers
+export const notStarknetFromWidened: RpcProvider = getProvider(widenedString);

--- a/test/types/provider.test-d.ts
+++ b/test/types/provider.test-d.ts
@@ -39,3 +39,11 @@ export const notStarknetFromUntyped: RpcProvider = getProvider(untyped);
 
 // @ts-expect-error a network the compiler cannot pin resolves to ethers
 export const notStarknetFromWidened: RpcProvider = getProvider(widenedString);
+
+// @ts-expect-error a Starknet network resolves to starknet.js, not ethers
+export const notEthersThroughPublicSurface: StaticJsonRpcProvider =
+  snapshot.utils.getProvider('0x534e5f4d41494e');
+
+// @ts-expect-error an EVM network resolves to ethers, not starknet.js
+export const notStarknetThroughPublicSurface: RpcProvider =
+  snapshot.utils.getProvider('1');

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*", "test/types/**/*"]
+}


### PR DESCRIPTION
Closes #1233.

`utils.getProvider` returned `any`, so every call site was unchecked, and a consumer that wanted a real type had to assert one itself with nothing verifying the assertion.

The runtime already discriminates exactly, on the `starknet` flag in `networks.json`. This puts that in the signature: a network the compiler can pin to a Starknet id resolves to starknet.js's `RpcProvider`, everything else resolves to `StaticJsonRpcProvider`. The implementation does not change.

A network the compiler cannot pin, whether a widened `string`/`number` or an `any`, resolves to `StaticJsonRpcProvider`. That case carries most of the weight here. Consumers set `noImplicitAny: false` nearly everywhere, so an untyped network argument is ordinary rather than exotic, and resolving those to the Starknet provider would trade an honest `any` for a confident wrong answer. It is the behaviour the type has to get right to be safe to adopt, so it is most of what the type test covers.

`src/verify/starknet.ts` is the first thing the narrowing caught: it took a widened `string` and called `getClassAt` and `verifyMessageInStarknet` on what the compiler now reads as an ethers provider. Its parameter is typed to the Starknet ids. The exported `verify` already casts at dispatch, so its signature is unchanged.

The Starknet id list is a literal union rather than something derived from `networks.json`, because deriving it puts a JSON import into the emitted `.d.ts` and consumers would then need `resolveJsonModule` to read our types. A test pins the union to `networks.json` instead, since that file is updated by a workflow rather than by hand.

A consumer that wraps `getProvider` behind its own `string | number` signature collapses both branches onto the EVM one. Making that wrapper generic is enough to restore it, and nothing needs to be imported from here. Inside a generic wrapper the return is still an unresolved conditional, so it propagates to callers but cannot be dereferenced in the wrapper itself without first widening it to `StaticJsonRpcProvider | RpcProvider`.
