### PR TITLE
feat(provider): add RPC client attribution

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -611,7 +611,8 @@ export async function getShibariumNameOwner(
 
 export async function getUDNameOwner(
   id: string,
-  network: string
+  network: string,
+  options: any = {}
 ): Promise<string> {
   const tlds = UD_MAPPING[network]?.tlds || [];
   if (!tlds.some((tld: string) => id.endsWith(tld))) {
@@ -621,7 +622,7 @@ export async function getUDNameOwner(
   try {
     const hash = namehash(ensNormalize(id));
     const tokenId = BigInt(hash);
-    const provider = getProvider(network);
+    const provider = getProvider(network, options);
 
     return await call(
       provider,
@@ -646,7 +647,7 @@ export async function getSpaceController(
   } else if (SHIBARIUM_CHAIN_IDS.includes(network)) {
     return getShibariumNameOwner(id, network);
   } else if (UD_MAPPING[String(network)]) {
-    return getUDNameOwner(id, network);
+    return getUDNameOwner(id, network, options);
   }
 
   throw new Error(`Network not supported: ${network}`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import addErrors from 'ajv-errors';
 import { getSnapshots } from './utils/blockfinder';
-import getProvider from './utils/provider';
+import getProvider, { type ProviderOptions } from './utils/provider';
 import { getEnsTextRecord, getEnsOwner } from './utils/ens';
 import { signMessage, getBlockNumber } from './utils/web3';
 import { getHash, verify } from './verify';
@@ -612,7 +612,7 @@ export async function getShibariumNameOwner(
 export async function getUDNameOwner(
   id: string,
   network: string,
-  options: any = {}
+  options: ProviderOptions = {}
 ): Promise<string> {
   const tlds = UD_MAPPING[network]?.tlds || [];
   if (!tlds.some((tld: string) => id.endsWith(tld))) {

--- a/src/utils/ens.spec.ts
+++ b/src/utils/ens.spec.ts
@@ -4,8 +4,10 @@ import { packetToBytes } from 'viem/ens';
 import { getEnsTextRecord, getEnsOwner } from './ens';
 import { getSpaceController } from '../utils';
 import { getViemClient } from './viem';
+import getProvider from './provider';
 
 vi.mock('./viem', () => ({ getViemClient: vi.fn() }));
+vi.mock('./provider', () => ({ default: vi.fn() }));
 
 const EMPTY = '0x0000000000000000000000000000000000000000';
 const OWNER = '0x1208a26FAa0F4AC65B42098419EB4dAA5e580AC6';
@@ -38,6 +40,7 @@ function mockClient(overrides: Record<string, any> = {}) {
 
 beforeEach(() => {
   vi.mocked(getViemClient).mockReset();
+  vi.mocked(getProvider).mockReset();
 });
 
 describe('getEnsTextRecord fail-closed classification', () => {
@@ -96,6 +99,31 @@ describe('getEnsTextRecord fail-closed classification', () => {
 });
 
 describe('getSpaceController fail-closed', () => {
+  test('forwards the client name to its provider', async () => {
+    const client = mockClient();
+    client.getEnsText.mockResolvedValue(OWNER);
+
+    await expect(
+      getSpaceController('x.eth', '1', { clientName: 'sequencer' })
+    ).resolves.toBe(OWNER);
+    expect(getViemClient).toHaveBeenCalledWith('1', {
+      clientName: 'sequencer'
+    });
+  });
+
+  test('forwards the client name to the Sonic provider', async () => {
+    vi.mocked(getProvider).mockImplementation(() => {
+      throw new Error('stop');
+    });
+
+    await expect(
+      getSpaceController('review.sonic', '146', { clientName: 'sequencer' })
+    ).resolves.toBe(EMPTY);
+    expect(getProvider).toHaveBeenCalledWith('146', {
+      clientName: 'sequencer'
+    });
+  });
+
   test('rejects when the record read fails instead of falling back to the owner', async () => {
     const client = mockClient();
     client.getEnsText.mockRejectedValue(revertError('HttpError', 503));

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -6,7 +6,11 @@ import networks from '../networks.json';
 export interface ProviderOptions {
   readonly broviderUrl?: string;
   readonly timeout?: number;
+  readonly clientName?: string;
 }
+
+type NormalizedProviderOptions = Required<Omit<ProviderOptions, 'clientName'>> &
+  Pick<ProviderOptions, 'clientName'>;
 
 type ProviderInstance = StaticJsonRpcProvider | RpcProvider;
 
@@ -20,13 +24,14 @@ export const STARKNET_NETWORK_IDS = [
 export type StarknetNetworkId = typeof STARKNET_NETWORK_IDS[number];
 
 const DEFAULT_BROVIDER_URL = 'https://rpc.snapshot.org' as const;
+const CLIENT_NAME_PATTERN = /^[a-z0-9.-]{1,32}$/i;
 export const DEFAULT_TIMEOUT = 25000 as const;
 
 const providerMemo = new Map<string, ProviderInstance>();
 
 const providerFnMap: Record<
   ProviderType,
-  (networkId: string, options: Required<ProviderOptions>) => ProviderInstance
+  (networkId: string, options: NormalizedProviderOptions) => ProviderInstance
 > = {
   evm: getEvmProvider,
   starknet: getStarknetProvider
@@ -34,11 +39,19 @@ const providerFnMap: Record<
 
 export function normalizeOptions(
   options: ProviderOptions = {}
-): Required<ProviderOptions> {
-  const { timeout } = options;
+): NormalizedProviderOptions {
+  const { timeout, clientName } = options;
+
+  if (
+    clientName !== undefined &&
+    (typeof clientName !== 'string' || !CLIENT_NAME_PATTERN.test(clientName))
+  ) {
+    throw new Error('Invalid clientName');
+  }
 
   return {
     broviderUrl: options.broviderUrl || DEFAULT_BROVIDER_URL,
+    clientName,
     // Not `??`: it passes `NaN` through (`Number()` of an unset env var), and
     // `setTimeout(..., NaN)` fires on the next tick, aborting every request.
     timeout:
@@ -64,9 +77,25 @@ export function getProviderType(network: string | number): ProviderType {
 
 export function createMemoKey(
   networkId: string,
-  options: Required<ProviderOptions>
+  options: NormalizedProviderOptions
 ): string {
-  return `${networkId}:${options.broviderUrl}:${options.timeout}`;
+  const key = `${networkId}:${options.broviderUrl}:${options.timeout}`;
+  return options.clientName
+    ? JSON.stringify([
+        networkId,
+        options.broviderUrl,
+        options.timeout,
+        options.clientName
+      ])
+    : key;
+}
+
+export function createProviderUrl(
+  networkId: string,
+  options: NormalizedProviderOptions
+): string {
+  const url = `${options.broviderUrl}/${networkId}`;
+  return options.clientName ? `${url}?client=${options.clientName}` : url;
 }
 
 type IsAny<T> = 0 extends 1 & T ? true : false;
@@ -103,11 +132,11 @@ export default function getProvider(
 
 function getEvmProvider(
   networkId: string,
-  options: Required<ProviderOptions>
+  options: NormalizedProviderOptions
 ): StaticJsonRpcProvider {
   return new StaticJsonRpcProvider(
     {
-      url: `${options.broviderUrl}/${networkId}`,
+      url: createProviderUrl(networkId, options),
       timeout: options.timeout,
       allowGzip: true
     },
@@ -125,10 +154,10 @@ const starknetTimeoutError = (timeout: number) =>
 
 function getStarknetProvider(
   networkKey: string,
-  options: Required<ProviderOptions>
+  options: NormalizedProviderOptions
 ): RpcProvider {
   return new RpcProvider({
-    nodeUrl: `${options.broviderUrl}/${networkKey}`,
+    nodeUrl: createProviderUrl(networkKey, options),
     // At 0 there is no deadline to add, so leave starknet its own transport
     // (`baseFetch ?? ponyfill`) rather than swap the transport for nothing.
     // Native `fetch`, bound like starknet's own browser default: the package

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -40,18 +40,20 @@ const providerFnMap: Record<
 export function normalizeOptions(
   options: ProviderOptions = {}
 ): NormalizedProviderOptions {
-  const { timeout, clientName } = options;
+  const { timeout } = options;
+  let { clientName } = options;
 
   if (
     clientName !== undefined &&
     (typeof clientName !== 'string' || !CLIENT_NAME_PATTERN.test(clientName))
   ) {
-    throw new Error('Invalid clientName');
+    console.warn(`Ignoring invalid clientName: ${String(clientName)}`);
+    clientName = undefined;
   }
 
   return {
     broviderUrl: options.broviderUrl || DEFAULT_BROVIDER_URL,
-    clientName,
+    clientName: clientName?.toLowerCase(),
     // Not `??`: it passes `NaN` through (`Number()` of an unset env var), and
     // `setTimeout(..., NaN)` fires on the next tick, aborting every request.
     timeout:
@@ -79,15 +81,9 @@ export function createMemoKey(
   networkId: string,
   options: NormalizedProviderOptions
 ): string {
-  const key = `${networkId}:${options.broviderUrl}:${options.timeout}`;
-  return options.clientName
-    ? JSON.stringify([
-        networkId,
-        options.broviderUrl,
-        options.timeout,
-        options.clientName
-      ])
-    : key;
+  return `${networkId}:${options.broviderUrl}:${options.timeout}:${
+    options.clientName ?? ''
+  }`;
 }
 
 export function createProviderUrl(

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -47,7 +47,7 @@ export function normalizeOptions(
     clientName !== undefined &&
     (typeof clientName !== 'string' || !CLIENT_NAME_PATTERN.test(clientName))
   ) {
-    console.warn(`Ignoring invalid clientName: ${String(clientName)}`);
+    console.warn('Ignoring invalid clientName');
     clientName = undefined;
   }
 

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -47,7 +47,7 @@ export function normalizeOptions(
     clientName !== undefined &&
     (typeof clientName !== 'string' || !CLIENT_NAME_PATTERN.test(clientName))
   ) {
-    console.warn('Ignoring invalid clientName');
+    console.warn('Ignoring invalid clientName:', clientName);
     clientName = undefined;
   }
 

--- a/src/utils/viem.ts
+++ b/src/utils/viem.ts
@@ -3,6 +3,7 @@ import type { CcipRequestParameters } from 'viem';
 import {
   ProviderOptions,
   createMemoKey,
+  createProviderUrl,
   getBroviderNetworkId,
   getProviderType,
   normalizeOptions
@@ -48,7 +49,7 @@ export function getViemClient(
       normalizedOptions.timeout > 0
         ? ccipReadWithDeadline(normalizedOptions.timeout)
         : undefined,
-    transport: http(`${normalizedOptions.broviderUrl}/${networkId}`, {
+    transport: http(createProviderUrl(networkId, normalizedOptions), {
       // single attempt within the timeout, like the ethers provider
       retryCount: 0,
       timeout: normalizedOptions.timeout

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -51,10 +51,10 @@ describe('test providers', () => {
       );
     });
 
-    test('should add the client name to EVM and Starknet provider URLs', () => {
-      const evmProvider = getProvider('1', { clientName: 'sequencer' });
+    test('should add a lowercase client name to EVM and Starknet provider URLs', () => {
+      const evmProvider = getProvider('1', { clientName: 'Sequencer' });
       const starknetProvider = getProvider(STARKNET_NETWORK, {
-        clientName: 'sequencer'
+        clientName: 'Sequencer'
       });
 
       expect(evmProvider.connection.url).toBe(
@@ -75,8 +75,8 @@ describe('test providers', () => {
       );
     });
 
-    test('should memoize providers by client name', () => {
-      const provider1 = getProvider('1', { clientName: 'sequencer' });
+    test('should memoize providers by lowercase client name', () => {
+      const provider1 = getProvider('1', { clientName: 'Sequencer' });
       const provider2 = getProvider('1', { clientName: 'sequencer' });
       const provider3 = getProvider('1', { clientName: 'score-api' });
 
@@ -168,16 +168,16 @@ describe('test providers', () => {
       );
     });
 
-    test('should add the client name to the transport URL', () => {
-      const client = getViemClient('1', { clientName: 'score-api' });
+    test('should add a lowercase client name to the transport URL', () => {
+      const client = getViemClient('1', { clientName: 'Score-API' });
 
       expect(client.transport.url).toBe(
         'https://rpc.snapshot.org/1?client=score-api'
       );
     });
 
-    test('should memoize clients by client name', () => {
-      const client1 = getViemClient('1', { clientName: 'score-api' });
+    test('should memoize clients by lowercase client name', () => {
+      const client1 = getViemClient('1', { clientName: 'Score-API' });
       const client2 = getViemClient('1', { clientName: 'score-api' });
       const client3 = getViemClient('1', { clientName: 'sequencer' });
 
@@ -476,15 +476,26 @@ describe('normalizeOptions()', () => {
     ['score-api#sequencer', 'hashes'],
     ['a'.repeat(33), 'more than 32 characters'],
     [null, 'non-string values']
-  ])('rejects client names with %s (%s)', (clientName) => {
-    expect(() => normalizeOptions({ clientName: clientName as any })).toThrow(
-      'Invalid clientName'
-    );
+  ])('ignores client names with %s (%s)', (clientName) => {
+    const warning = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+
+    try {
+      expect(
+        normalizeOptions({ clientName: clientName as any }).clientName
+      ).toBeUndefined();
+      expect(warning).toHaveBeenCalledWith(
+        `Ignoring invalid clientName: ${String(clientName)}`
+      );
+    } finally {
+      warning.mockRestore();
+    }
   });
 
-  test('preserves the memo key when no client name is set', () => {
+  test('uses a fixed memo key format without a client name', () => {
     expect(createMemoKey('1', normalizeOptions())).toBe(
-      '1:https://rpc.snapshot.org:25000'
+      '1:https://rpc.snapshot.org:25000:'
     );
   });
 

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -475,7 +475,8 @@ describe('normalizeOptions()', () => {
     ['score-api?client=sequencer', 'question marks'],
     ['score-api#sequencer', 'hashes'],
     ['a'.repeat(33), 'more than 32 characters'],
-    [null, 'non-string values']
+    [null, 'non-string values'],
+    [Object.create(null), 'non-coercible objects']
   ])('ignores client names with %s (%s)', (clientName) => {
     const warning = vi
       .spyOn(console, 'warn')
@@ -485,9 +486,7 @@ describe('normalizeOptions()', () => {
       expect(
         normalizeOptions({ clientName: clientName as any }).clientName
       ).toBeUndefined();
-      expect(warning).toHaveBeenCalledWith(
-        `Ignoring invalid clientName: ${String(clientName)}`
-      );
+      expect(warning).toHaveBeenCalledWith('Ignoring invalid clientName');
     } finally {
       warning.mockRestore();
     }

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
 import { AddressInfo, createServer, Server, Socket } from 'net';
 import getProvider, {
   DEFAULT_TIMEOUT,
+  createMemoKey,
   getProviderType,
   normalizeOptions,
   STARKNET_NETWORK_IDS
@@ -48,6 +49,53 @@ describe('test providers', () => {
           .filter((id) => getProviderType(id) === 'starknet')
           .sort()
       );
+    });
+
+    test('should add the client name to EVM and Starknet provider URLs', () => {
+      const evmProvider = getProvider('1', { clientName: 'sequencer' });
+      const starknetProvider = getProvider(STARKNET_NETWORK, {
+        clientName: 'sequencer'
+      });
+
+      expect(evmProvider.connection.url).toBe(
+        'https://rpc.snapshot.org/1?client=sequencer'
+      );
+      expect(starknetProvider.channel.nodeUrl).toBe(
+        'https://rpc.snapshot.org/sn?client=sequencer'
+      );
+    });
+
+    test('should leave provider URLs unchanged without a client name', () => {
+      const evmProvider = getProvider('1');
+      const starknetProvider = getProvider(STARKNET_NETWORK);
+
+      expect(evmProvider.connection.url).toBe('https://rpc.snapshot.org/1');
+      expect(starknetProvider.channel.nodeUrl).toBe(
+        'https://rpc.snapshot.org/sn'
+      );
+    });
+
+    test('should memoize providers by client name', () => {
+      const provider1 = getProvider('1', { clientName: 'sequencer' });
+      const provider2 = getProvider('1', { clientName: 'sequencer' });
+      const provider3 = getProvider('1', { clientName: 'score-api' });
+
+      expect(provider1).toBe(provider2);
+      expect(provider1).not.toBe(provider3);
+    });
+
+    test('should not collide with legacy memo keys', () => {
+      const provider1 = getProvider('1', {
+        broviderUrl: 'http://localhost:3000',
+        timeout: 25000
+      });
+      const provider2 = getProvider('1', {
+        broviderUrl: 'http://localhost',
+        timeout: 3000,
+        clientName: '25000'
+      });
+
+      expect(provider1).not.toBe(provider2);
     });
 
     test('should memoize providers with same network and options', () => {
@@ -112,6 +160,29 @@ describe('test providers', () => {
       expect(() => getViemClient('0x534e5f4d41494e')).toThrowError(
         "Network '0x534e5f4d41494e' is not supported"
       );
+    });
+
+    test('should leave the transport URL unchanged without a client name', () => {
+      expect(getViemClient('1').transport.url).toBe(
+        'https://rpc.snapshot.org/1'
+      );
+    });
+
+    test('should add the client name to the transport URL', () => {
+      const client = getViemClient('1', { clientName: 'score-api' });
+
+      expect(client.transport.url).toBe(
+        'https://rpc.snapshot.org/1?client=score-api'
+      );
+    });
+
+    test('should memoize clients by client name', () => {
+      const client1 = getViemClient('1', { clientName: 'score-api' });
+      const client2 = getViemClient('1', { clientName: 'score-api' });
+      const client3 = getViemClient('1', { clientName: 'sequencer' });
+
+      expect(client1).toBe(client2);
+      expect(client1).not.toBe(client3);
     });
 
     test('should memoize clients with same network and options', () => {
@@ -395,6 +466,28 @@ describe('Starknet provider timeout', () => {
 });
 
 describe('normalizeOptions()', () => {
+  test.each([
+    ['', 'empty'],
+    ['space name', 'spaces'],
+    ['client_name', 'underscores'],
+    ['score-api&client=sequencer', 'ampersands'],
+    ['score-api=sequencer', 'equals signs'],
+    ['score-api?client=sequencer', 'question marks'],
+    ['score-api#sequencer', 'hashes'],
+    ['a'.repeat(33), 'more than 32 characters'],
+    [null, 'non-string values']
+  ])('rejects client names with %s (%s)', (clientName) => {
+    expect(() => normalizeOptions({ clientName: clientName as any })).toThrow(
+      'Invalid clientName'
+    );
+  });
+
+  test('preserves the memo key when no client name is set', () => {
+    expect(createMemoKey('1', normalizeOptions())).toBe(
+      '1:https://rpc.snapshot.org:25000'
+    );
+  });
+
   test.each([
     [undefined, DEFAULT_TIMEOUT],
     [NaN, DEFAULT_TIMEOUT],

--- a/test/integration/utils/providers.spec.ts
+++ b/test/integration/utils/providers.spec.ts
@@ -486,7 +486,10 @@ describe('normalizeOptions()', () => {
       expect(
         normalizeOptions({ clientName: clientName as any }).clientName
       ).toBeUndefined();
-      expect(warning).toHaveBeenCalledWith('Ignoring invalid clientName');
+      expect(warning).toHaveBeenCalledWith(
+        'Ignoring invalid clientName:',
+        clientName
+      );
     } finally {
       warning.mockRestore();
     }


### PR DESCRIPTION
Closes #1238.

Adds a validated `clientName` provider option and applies it consistently to ethers, Starknet, and viem RPC URLs. Provider memoization separates attributed clients while preserving existing URLs and memoization for callers that omit the option.

Existing space-resolution option forwarding carries the attribution through helpers that create viem clients internally.
