### PR TITLE
fix: replace `lodash.set` with a local prototype-pollution-safe `set`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "ajv-formats": "^2.1.1",
     "cross-fetch": "^3.1.6",
     "json-to-graphql-query": "^2.2.4",
-    "lodash.set": "^4.3.2",
     "starknet": "^6.21.0",
     "viem": "^2.55.11"
   },

--- a/src/multicall/multicaller.ts
+++ b/src/multicall/multicaller.ts
@@ -1,9 +1,7 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
-import set from 'lodash.set';
 import { RpcProvider } from 'starknet';
 import { multicall } from './';
-
-type Path = string | number | number[] | string[];
+import set, { Path } from '../utils/set';
 
 export default class Multicaller {
   public network: string;

--- a/src/utils/set.spec.ts
+++ b/src/utils/set.spec.ts
@@ -1,0 +1,140 @@
+import { describe, test, expect } from 'vitest';
+import set from './set';
+
+describe('set', () => {
+  describe('prototype pollution', () => {
+    // `lodash.set` is affected by GHSA-p6mc-m468-83gw with no patched release,
+    // so these paths must never reach `Object.prototype`.
+    const attacks: [string, any][] = [
+      ['__proto__ as a leading key', '__proto__.polluted'],
+      ['constructor.prototype chain', 'constructor.prototype.polluted'],
+      ['__proto__ nested in the path', 'a.__proto__.polluted'],
+      ['prototype as a leading key', 'prototype.polluted'],
+      ['bracketed __proto__', 'a["__proto__"]["polluted"]'],
+      ['array path', ['__proto__', 'polluted']],
+      ['array path with constructor', ['a', 'constructor', 'polluted']]
+    ];
+
+    test.each(attacks)('does not pollute via %s', (_label, path) => {
+      set({}, path, 'polluted-value');
+
+      expect(({} as any).polluted).toBeUndefined();
+      expect(Object.prototype).not.toHaveProperty('polluted');
+    });
+
+    test('leaves the assignment unperformed', () => {
+      expect(set({}, '__proto__.polluted', 'V')).toEqual({});
+      expect(set({}, 'constructor.prototype.polluted', 'V')).toEqual({});
+      // containers created before the forbidden key are kept, as in lodash
+      expect(set({}, 'a.__proto__.polluted', 'V')).toEqual({ a: {} });
+    });
+
+    test('does not assign a forbidden key even as the last segment', () => {
+      expect(set({}, 'a.constructor', 'V')).toEqual({ a: {} });
+    });
+  });
+
+  describe('assignment', () => {
+    test('sets a top-level key', () => {
+      expect(set({}, 'a', 'V')).toEqual({ a: 'V' });
+    });
+
+    test('sets a nested key, creating missing objects', () => {
+      expect(set({}, 'a.b.c', 'V')).toEqual({ a: { b: { c: 'V' } } });
+    });
+
+    test('overwrites an existing value', () => {
+      expect(set({ a: { b: 1 } }, 'a', 'V')).toEqual({ a: 'V' });
+    });
+
+    test('replaces primitives standing in for containers', () => {
+      expect(set({ a: 1 }, 'a.b', 'V')).toEqual({ a: { b: 'V' } });
+      expect(set({ a: null }, 'a.b', 'V')).toEqual({ a: { b: 'V' } });
+    });
+
+    test('merges into an existing structure', () => {
+      const object = { a: { keep: 1 } };
+
+      expect(set(object, 'a.added', 'V')).toEqual({
+        a: { keep: 1, added: 'V' }
+      });
+    });
+
+    test('returns the mutated object', () => {
+      const object = {};
+
+      expect(set(object, 'a', 'V')).toBe(object);
+    });
+
+    test('ignores non-object targets', () => {
+      expect(set(null, 'a', 'V')).toBe(null);
+      expect(set(42 as any, 'a', 'V')).toBe(42);
+    });
+  });
+
+  describe('path parsing', () => {
+    test('creates arrays for array-index keys', () => {
+      const result = set({}, 'a.0', 'V');
+
+      expect(Array.isArray(result.a)).toBe(true);
+      expect(result.a[0]).toBe('V');
+    });
+
+    test('creates objects for non-index keys', () => {
+      const result = set({}, 'a.00', 'V');
+
+      expect(Array.isArray(result.a)).toBe(false);
+      expect(result).toEqual({ a: { '00': 'V' } });
+      expect(set({}, 'a.-1', 'V')).toEqual({ a: { '-1': 'V' } });
+    });
+
+    test('reuses existing containers rather than converting them', () => {
+      const result = set({ a: {} }, 'a.0', 'V');
+
+      expect(Array.isArray(result.a)).toBe(false);
+      expect(result).toEqual({ a: { '0': 'V' } });
+    });
+
+    test('updates an existing array in place', () => {
+      expect(set({ a: [1, 2, 3] }, 'a.1', 'V')).toEqual({ a: [1, 'V', 3] });
+    });
+
+    test('supports bracket notation', () => {
+      expect(set({}, 'a[0].b', 'V')).toEqual({ a: [{ b: 'V' }] });
+      expect(set({}, 'a.b[0]', 'V')).toEqual({ a: { b: ['V'] } });
+    });
+
+    test('supports quoted keys containing dots', () => {
+      expect(set({}, 'a["x.y"]', 'V')).toEqual({ a: { 'x.y': 'V' } });
+      expect(set({}, "a['x']", 'V')).toEqual({ a: { x: 'V' } });
+    });
+
+    test('supports array paths', () => {
+      expect(set({}, ['a', 'b'], 'V')).toEqual({ a: { b: 'V' } });
+      expect(set({}, ['a', 'x.y'], 'V')).toEqual({ a: { 'x.y': 'V' } });
+
+      const result = set({}, ['a', '0'], 'V');
+      expect(Array.isArray(result.a)).toBe(true);
+      expect(result.a[0]).toBe('V');
+    });
+
+    test('supports numeric paths', () => {
+      expect(set({}, 0, 'V')).toEqual({ '0': 'V' });
+    });
+
+    test('treats a dotless string as a single key', () => {
+      expect(set({}, '0xAbC', 'V')).toEqual({ '0xAbC': 'V' });
+      expect(set({}, '', 'V')).toEqual({ '': 'V' });
+    });
+
+    test('keeps the empty key of leading and repeated separators', () => {
+      expect(set({}, '.a', 'V')).toEqual({ '': { a: 'V' } });
+      expect(set({}, 'a..b', 'V')).toEqual({ a: { '': { b: 'V' } } });
+    });
+
+    test('prefers an existing literal key over deep resolution', () => {
+      expect(set({ 'a.b': 1 }, 'a.b', 'V')).toEqual({ 'a.b': 'V' });
+      expect(set({}, 'a.b', 'V')).toEqual({ a: { b: 'V' } });
+    });
+  });
+});

--- a/src/utils/set.ts
+++ b/src/utils/set.ts
@@ -1,0 +1,106 @@
+// Minimal replacement for the standalone `lodash.set` package, which is
+// permanently affected by GHSA-p6mc-m468-83gw (prototype pollution): 4.3.2 is
+// both its latest and its last published version, so no patched release exists.
+//
+// Behaviour follows `lodash@4.17.21`, where the same flaw was fixed: `a.b`,
+// `a[0]`, `a['b']` and array paths all resolve identically, missing containers
+// are created as arrays when the next key is an array index and as plain
+// objects otherwise, existing containers are reused as-is, and keys that would
+// reach `Object.prototype` leave the assignment unperformed.
+
+export type Path = string | number | number[] | string[];
+
+// Matches a bare key (`a`), a bracketed index (`[0]`), or a bracketed quoted
+// key (`['a.b']`), capturing the index and the unquoted key separately. The
+// trailing lookahead yields the empty key of accessors like `a..b` and `a[].b`.
+const RE_PROP_NAME =
+  /[^.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|$))/g;
+const RE_ESCAPE_CHAR = /\\(\\)?/g;
+
+// A path is a single key (rather than a deep path) when it is a plain word, or
+// contains no `.`/`[]` accessor at all, or already exists on the target.
+const RE_IS_PLAIN_PROP = /^\w*$/;
+const RE_IS_DEEP_PROP = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]/;
+
+// Keys that resolve to `Object.prototype` and therefore must never be walked
+// into or assigned to.
+const FORBIDDEN_KEYS = ['__proto__', 'constructor', 'prototype'];
+
+// Mirrors lodash's `isIndex`: a non-negative integer without leading zeros.
+const RE_IS_INDEX = /^(?:0|[1-9]\d*)$/;
+
+function isIndex(value: string | number): boolean {
+  return (
+    (typeof value === 'number' || RE_IS_INDEX.test(value)) &&
+    Number(value) > -1 &&
+    Number(value) % 1 === 0 &&
+    Number(value) < Number.MAX_SAFE_INTEGER
+  );
+}
+
+function isObject(value: any): boolean {
+  return (
+    value != null && (typeof value === 'object' || typeof value === 'function')
+  );
+}
+
+function stringToPath(value: string): string[] {
+  const result: string[] = [];
+
+  // A leading dot denotes an empty first key, e.g. `.a` -> ['', 'a'].
+  if (value.charCodeAt(0) === 46) result.push('');
+
+  value.replace(RE_PROP_NAME, (match, index, quote, quotedKey) => {
+    result.push(
+      quote ? quotedKey.replace(RE_ESCAPE_CHAR, '$1') : index || match
+    );
+    return match;
+  });
+
+  return result;
+}
+
+function isKey(value: string, object: any): boolean {
+  if (RE_IS_PLAIN_PROP.test(value) || !RE_IS_DEEP_PROP.test(value)) return true;
+
+  return object != null && value in Object(object);
+}
+
+function castPath(path: Path, object: any): string[] {
+  if (Array.isArray(path)) return path.map((key) => String(key));
+  if (typeof path === 'number') return [String(path)];
+
+  return isKey(path, object) ? [path] : stringToPath(path);
+}
+
+/**
+ * Sets `value` at `path` of `object`, creating any missing intermediate
+ * containers. Paths containing `__proto__`, `constructor` or `prototype` are
+ * ignored, leaving the assignment unperformed.
+ */
+export default function set(object: any, path: Path, value: any): any {
+  if (!isObject(object)) return object;
+
+  const keys = castPath(path, object);
+  const lastIndex = keys.length - 1;
+  let nested = object;
+
+  for (let index = 0; index <= lastIndex && nested != null; index++) {
+    const key = keys[index];
+
+    if (FORBIDDEN_KEYS.includes(key)) return object;
+
+    if (index === lastIndex) {
+      nested[key] = value;
+    } else {
+      // Reuse whatever is already there, otherwise create a container matching
+      // the shape implied by the next key.
+      if (!isObject(nested[key])) {
+        nested[key] = isIndex(keys[index + 1]) ? [] : {};
+      }
+      nested = nested[key];
+    }
+  }
+
+  return object;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3415,11 +3415,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==
-
 lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"


### PR DESCRIPTION
Closes #1046

## Why

The standalone `lodash.set` package is affected by [GHSA-p6mc-m468-83gw](https://github.com/advisories/GHSA-p6mc-m468-83gw) (prototype pollution, **high**), and it cannot be resolved by upgrading or downgrading:

- the advisory covers `>= 3.7.0, <= 4.3.2` and reports **no patched version**
- `4.3.2` is both the **latest** and the **last** published version (June 2022)

So every consumer of snapshot.js currently gets:

```
lodash.set  *
Severity: high
Prototype Pollution in lodash - https://github.com/advisories/GHSA-p6mc-m468-83gw
No fix available
```

All four pollution vectors reproduce on the pinned version:

```js
set({}, '__proto__.polluted', 'yes');
set({}, 'constructor.prototype.polluted', 'yes');
set({}, ['__proto__', 'polluted'], 'yes');
set({}, 'a["__proto__"]["polluted"]', 'yes');
// -> ({}).polluted === 'yes'
```

Mainline `lodash` fixed exactly this in 4.17.20 by rejecting `__proto__`, `constructor` and `prototype` path segments; that fix was never backported to the standalone package.

## What

`lodash.set` had a single call site, in `Multicaller.execute()`, so this removes the dependency and adds a local `src/utils/set.ts` modelled on `lodash@4.17.21`.

Behaviour is intentionally unchanged for every valid path:

- path resolution (`a.b`, `a[0]`, `a['b.c']`, array and numeric paths)
- containers created as arrays when the next key is an array index (`balances.0` still yields an array) and as plain objects otherwise
- existing containers reused rather than converted, primitives replaced
- the `isKey` fast path, so an existing literal key like `'a.b'` still wins over deep resolution

The only difference is the security guard: a path containing `__proto__`, `constructor` or `prototype` leaves the assignment unperformed, matching `lodash@4.17.21`.

## Testing

- new `src/utils/set.spec.ts`: 27 tests, 100% statement/branch/function/line coverage of `set.ts`, covering the pollution vectors and the path-resolution rules above
- during development I ran a differential harness against `lodash@4.17.21` over a matrix of paths x seed objects plus 20,000 randomized fuzz paths, asserting identical results and identical thrown errors — no divergence. It is not committed, to avoid adding a `lodash` devDependency to a PR whose purpose is removing lodash
- the existing `Multicaller` integration tests (11, against live RPC) pass unchanged, including the cases that build array paths (`balances.${i}`, `calls.${i}`)
- `yarn lint`, `yarn typecheck`, `yarn build` and `yarn install --frozen-lockfile` are clean; the `yarn.lock` change is limited to removing the dropped entry

Happy to adjust the approach if you would rather vendor a different helper or keep `Path` where it was.