### PR TITLE
Add new networks Robinhood Chain - 4663 & 46630

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapshot-labs/snapshot.js",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "repository": "snapshot-labs/snapshot.js",
   "license": "MIT",
   "main": "dist/snapshot.cjs.js",

--- a/src/networks.json
+++ b/src/networks.json
@@ -1598,12 +1598,12 @@
     "shortName": "testnet",
     "chainId": 46630,
     "network": "testnet",
-    "multicall": "0xa432504b6F04Cafe775b09D8AA92e8dbe41Ec7a8",
+    "multicall": "0xcA11bde05977b3631167028862bE2a173976CA11",
     "rpc": [],
     "explorer": {
       "url": "https://explorer.testnet.chain.robinhood.com"
     },
-    "start": 1,
+    "start": 2065766,
     "logo": "ipfs://bafkreieuri5iyuxyku5ampl554fyc6iar7xyzwbd72e53gn5fs7dnd42uu",
     "testnet": true
   },

--- a/src/networks.json
+++ b/src/networks.json
@@ -1134,6 +1134,20 @@
     "start": 1,
     "logo": "ipfs://QmaKRLxXPdeTsLx7MFLS3CJbhpSbResgoeL4fCgHB1mTsF"
   },
+  "4663": {
+    "key": "4663",
+    "name": "Robinhood Chain",
+    "shortName": "Robinhood Chain",
+    "chainId": 4663,
+    "network": "mainnet",
+    "multicall": "0x2cAC2D899eCC914d704FeaAE33ac1bF36277DaD1",
+    "rpc": [],
+    "explorer": {
+      "url": "https://robinhoodchain.blockscout.com"
+    },
+    "start": 1,
+    "logo": "ipfs://bafkreieuri5iyuxyku5ampl554fyc6iar7xyzwbd72e53gn5fs7dnd42uu"
+  },
   "4689": {
     "key": "4689",
     "name": "IoTeX",
@@ -1577,6 +1591,21 @@
     },
     "start": 536483,
     "logo": "ipfs://QmeS75uS7XLR8o8uUzhLRVYPX9vMFf4DXgKxQeCzyy7vM2"
+  },
+  "46630": {
+    "key": "46630",
+    "name": "Robinhood Chain Testnet",
+    "shortName": "testnet",
+    "chainId": 46630,
+    "network": "testnet",
+    "multicall": "0xa432504b6F04Cafe775b09D8AA92e8dbe41Ec7a8",
+    "rpc": [],
+    "explorer": {
+      "url": "https://explorer.testnet.chain.robinhood.com"
+    },
+    "start": 1,
+    "logo": "ipfs://bafkreieuri5iyuxyku5ampl554fyc6iar7xyzwbd72e53gn5fs7dnd42uu",
+    "testnet": true
   },
   "47805": {
     "key": "47805",

--- a/src/networks.json
+++ b/src/networks.json
@@ -1140,12 +1140,12 @@
     "shortName": "Robinhood Chain",
     "chainId": 4663,
     "network": "mainnet",
-    "multicall": "0x2cAC2D899eCC914d704FeaAE33ac1bF36277DaD1",
+    "multicall": "0xcA11bde05977b3631167028862bE2a173976CA11",
     "rpc": [],
     "explorer": {
       "url": "https://robinhoodchain.blockscout.com"
     },
-    "start": 1,
+    "start": 0,
     "logo": "ipfs://bafkreieuri5iyuxyku5ampl554fyc6iar7xyzwbd72e53gn5fs7dnd42uu"
   },
   "4689": {


### PR DESCRIPTION
Adds Robinhood Chain mainnet (`4663`) and testnet (`46630`) to `src/networks.json`, with explorers and a shared IPFS logo. Both use Multicall3 at `0xcA11bde05977b3631167028862bE2a173976CA11`.

- Mainnet: `start: 0`, because Multicall3 is predeployed in the [official genesis allocation](https://cdn.robinhood.com/assets/generated_assets/hoodchain_docsite/chain-node-configs/robinhood-genesis.json). Its live runtime bytecode exactly matches the genesis code.
- Testnet: `start: 2065766`, the verified Multicall3 deployment block, and `testnet: true`.

Part of https://github.com/snapshot-labs/workflow/issues/846. Both networks should be configured as non-premium (`premium = 0`). RPC configuration, database registration, and the SDK release/consumer deployments remain rollout steps.

MySQL commands, after checking for existing rows in each database.

Production hub DB: add Robinhood Chain mainnet only.

```sql
INSERT INTO networks (id, name, premium, testnet)
VALUES ('4663', 'Robinhood Chain', 0, 0);
```

Testnet hub DB: add both mainnet and testnet.

```sql
INSERT INTO networks (id, name, premium, testnet)
VALUES
  ('4663', 'Robinhood Chain', 0, 0),
  ('46630', 'Robinhood Chain Testnet', 0, 1);
```

Brovider DB setup template: replace the placeholders with verified archive RPC URLs before running. These endpoints are not included in the public network registry (`rpc: []`).

```sql
INSERT INTO public.nodes (main, network, provider, url)
VALUES
  (1, '4663', 0, '<MAINNET_ARCHIVE_RPC_URL>'),
  (1, '46630', 0, '<TESTNET_ARCHIVE_RPC_URL>');
```

The public mainnet RPC serves historical blocks, but historical contract-state reads failed with `metadata is not found`; a working archive endpoint is required for fixed-block voting power. Testnet archive support still needs verification on the selected production endpoint.

Validation:

- Live RPC checks confirmed both chain IDs and successful `aggregate` calls for the configured multicalls. Mainnet also returned a WETH total-supply read through multicall. The testnet explorer confirms Multicall3 deployment at block `2065766` ([transaction](https://explorer.testnet.chain.robinhood.com/tx/0x07471adfe8f4ec553c1199f495be97fc8be8e0626ae307281c22534460184ed1)).
- Local registry checks passed for IDs, address checksums, testnet flags, explorer URLs, and the shared IPFS URI; all existing network entries are unchanged.
- `git diff --check` passed. The full build/test suite was not run. Prettier reports existing formatting issues in the baseline file as well.

References: [network details](https://docs.robinhood.com/chain/connecting/), [official node/genesis configuration](https://docs.robinhood.com/chain/run-a-full-node/). Description/setup format follows [Hedera #1136](https://github.com/snapshot-labs/snapshot.js/pull/1136) and [Horizen #1211](https://github.com/snapshot-labs/snapshot.js/pull/1211).
